### PR TITLE
fix: sync terraform state + node group v2 + deployment fixes

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,7 @@
 VITE_SUPABASE_PROJECT_ID="bqkpxdjmpbucenbppxzc"
 VITE_SUPABASE_PUBLISHABLE_KEY="eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImJxa3B4ZGptcGJ1Y2VuYnBweHpjIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTk0MDI5NDEsImV4cCI6MjA3NDk3ODk0MX0.xhjsBo_ID3Z5UlR1_uQIc-vgeIulYVJJ3p59Lel-7tQ"
 VITE_SUPABASE_URL="https://bqkpxdjmpbucenbppxzc.supabase.co"
+# Backend API — production EKS cluster via ALB (HTTPS once DNS propagates)
+VITE_API_URL="https://api.devonn.ai"
+# MCP Gateway — Supabase edge function proxies to the backend
+VITE_MCP_GATEWAY_URL="https://bqkpxdjmpbucenbppxzc.supabase.co/functions/v1/mcp-gateway"

--- a/src/hooks/useServiceHealth.ts
+++ b/src/hooks/useServiceHealth.ts
@@ -18,13 +18,18 @@ export interface ServiceStatus {
   error?: string;
 }
 
+// Production backend URLs — EKS cluster on AWS (us-west-2)
+const BACKEND_URL = import.meta.env.VITE_API_URL || "https://api.devonn.ai";
+const MCP_GATEWAY_URL =
+  import.meta.env.VITE_MCP_GATEWAY_URL ||
+  "https://bqkpxdjmpbucenbppxzc.supabase.co/functions/v1/mcp-gateway";
+
 const DEFAULT_ENDPOINTS: ServiceEndpoint[] = [
-  { id: "fastapi", name: "FastAPI", url: "http://localhost:8000/health", description: "Main API orchestration service", icon: "⚡" },
-  { id: "n8n", name: "n8n Workflows", url: "http://localhost:5678/healthz", description: "Workflow automation engine", icon: "🔄" },
-  { id: "mcp-gateway", name: "MCP Gateway", url: "http://localhost:3001/health", description: "Model Context Protocol server", icon: "🔌" },
-  { id: "openclawd", name: "OpenClawd", url: "http://localhost:8080/health", description: "AI model inference service", icon: "🧠" },
-  { id: "postgres", name: "PostgreSQL", url: "http://localhost:5432", description: "Primary database", icon: "🗄️" },
-  { id: "redis", name: "Redis", url: "http://localhost:6379", description: "Cache & message broker", icon: "📦" },
+  { id: "backend", name: "Devonn Backend", url: `${BACKEND_URL}/api/health`, description: "Flask API on EKS (Flask + MongoDB + Redis)", icon: "⚡" },
+  { id: "mcp-gateway", name: "MCP Gateway", url: MCP_GATEWAY_URL, description: "Supabase edge function → EKS MCP proxy", icon: "🔌" },
+  { id: "openclawd", name: "OpenClawd", url: `${BACKEND_URL}/api/health`, description: "AI model inference service", icon: "🧠" },
+  { id: "redis", name: "Redis (ElastiCache)", url: `${BACKEND_URL}/api/health`, description: "AWS ElastiCache Redis cache", icon: "📦" },
+  { id: "mongodb", name: "DocumentDB", url: `${BACKEND_URL}/api/health`, description: "AWS DocumentDB (MongoDB-compatible)", icon: "🗄️" },
 ];
 
 const STORAGE_KEY = "devonn-service-endpoints";

--- a/src/lib/mcp/serverRegistry.ts
+++ b/src/lib/mcp/serverRegistry.ts
@@ -238,10 +238,12 @@ export const MCP_SERVER_REGISTRY: McpServerConfig[] = [
   {
     id: "devonn-gateway",
     name: "DEVONN.AI Gateway",
-    description: "Connect to DEVONN.AI's central MCP gateway for unified tool access",
+    description: "Connect to DEVONN.AI's central MCP gateway for unified tool access (proxied via Supabase edge function)",
     category: "ai",
     type: "http",
-    gatewayUrl: "https://api.devonn.ai/mcp",
+    // Routes through the Supabase edge function which proxies to the EKS backend
+    // Once api.devonn.ai DNS is live, the edge function will use https://api.devonn.ai/mcp
+    gatewayUrl: "https://bqkpxdjmpbucenbppxzc.supabase.co/functions/v1/mcp-gateway",
     auth: {
       type: "api_token",
       envVar: "DEVONN_API_KEY",

--- a/supabase/functions/mcp-gateway/index.ts
+++ b/supabase/functions/mcp-gateway/index.ts
@@ -12,6 +12,12 @@ interface McpProxyRequest {
   gatewayUrl?: string;
 }
 
+// Default backend URL: prefer custom domain, fall back to ALB hostname
+// MCP_GATEWAY_URL can be set via Supabase Edge Function secrets:
+//   supabase secrets set MCP_GATEWAY_URL=https://api.devonn.ai/mcp --project-ref bqkpxdjmpbucenbppxzc
+const DEFAULT_GATEWAY_URL =
+  "http://devonn-alb-managed-2012536228.us-west-2.elb.amazonaws.com/api/mcp";
+
 serve(async (req) => {
   // Handle CORS preflight
   if (req.method === "OPTIONS") {
@@ -20,12 +26,13 @@ serve(async (req) => {
 
   try {
     const body: McpProxyRequest = await req.json();
-    
-    // Get gateway URL from header or body
-    const gatewayUrl = req.headers.get("x-mcp-gateway-url") 
-      ?? body.gatewayUrl 
-      ?? Deno.env.get("MCP_GATEWAY_URL")
-      ?? "http://gateway-remote:8080/mcp";
+
+    // Priority: request header > request body > env var > ALB default
+    const gatewayUrl =
+      req.headers.get("x-mcp-gateway-url") ??
+      body.gatewayUrl ??
+      Deno.env.get("MCP_GATEWAY_URL") ??
+      DEFAULT_GATEWAY_URL;
 
     console.log(`[mcp-gateway] Proxying ${body.method} to ${gatewayUrl}`);
 
@@ -37,7 +44,7 @@ serve(async (req) => {
       params: body.params ?? {},
     };
 
-    // Forward to MCP Gateway
+    // Forward to MCP Gateway backend
     const response = await fetch(gatewayUrl, {
       method: "POST",
       headers: {

--- a/terraform/aws/environments/prod/import.sh
+++ b/terraform/aws/environments/prod/import.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# =============================================================================
+# Terraform Import Script — Devonn AI Prod (us-west-2)
+# Account: 211125423223
+# Run from: terraform/aws/environments/prod/
+# Prereqs: terraform init, AWS credentials configured
+# =============================================================================
+set -euo pipefail
+
+echo "=== Initializing Terraform ==="
+terraform init
+
+echo ""
+echo "=== Importing EKS Cluster ==="
+terraform import module.eks.aws_eks_cluster.this devonn-eks-prod
+
+echo ""
+echo "=== Importing Cluster IAM Role ==="
+terraform import module.eks.aws_iam_role.cluster \
+  devonn-eks-prod-cluster-20251110070008631600000002
+
+echo ""
+echo "=== Importing Node Group IAM Role ==="
+terraform import module.eks.aws_iam_role.node_group \
+  dev_nodes-eks-node-group-20251110070005836700000001
+
+echo ""
+echo "=== Importing Launch Template ==="
+terraform import module.eks.aws_launch_template.node_group lt-0e4fdaa0ec426cc21
+
+echo ""
+echo "=== Importing EKS Node Group ==="
+terraform import module.eks.aws_eks_node_group.this \
+  devonn-eks-prod:devonn-nodes-v2
+
+echo ""
+echo "=== Importing ECR Repository ==="
+terraform import module.ecr.aws_ecr_repository.devonn_ai production/devonn-ai
+
+echo ""
+echo "=== Importing VPC ==="
+terraform import module.network.aws_vpc.this vpc-07efb80f704d0f144
+
+echo ""
+echo "=== Importing Private Subnets ==="
+terraform import "module.network.aws_subnet.private[0]" subnet-0db4ec070ec994d0e
+terraform import "module.network.aws_subnet.private[1]" subnet-07a4cb21c1445d536
+
+echo ""
+echo "=== Import complete. Running terraform plan to check drift ==="
+terraform plan -out=tfplan
+
+echo ""
+echo "Review the plan above. If it shows no changes, state is fully reconciled."
+echo "To apply any corrections: terraform apply tfplan"

--- a/terraform/aws/environments/prod/main.tf
+++ b/terraform/aws/environments/prod/main.tf
@@ -1,5 +1,21 @@
 terraform {
   required_version = ">= 1.5.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.45"
+    }
+  }
+
+  # Uncomment after running: terraform init -backend-config=...
+  # backend "s3" {
+  #   bucket         = "devonn-terraform-state"
+  #   key            = "prod/terraform.tfstate"
+  #   region         = "us-west-2"
+  #   dynamodb_table = "devonn-terraform-locks"
+  #   encrypt        = true
+  # }
 }
 
 provider "aws" {
@@ -44,6 +60,10 @@ output "cluster_endpoint" {
   value = module.eks.cluster_endpoint
 }
 
-output "ecr_repositories" {
+output "ecr_repository_url" {
   value = module.ecr.repository_urls
+}
+
+output "vpc_id" {
+  value = module.network.vpc_id
 }

--- a/terraform/aws/environments/prod/variables.tf
+++ b/terraform/aws/environments/prod/variables.tf
@@ -1,2 +1,64 @@
-variable "region" { default = "us-east-1" }
-variable "cluster_name" { default = "devonn-eks" }
+variable "region" {
+  description = "AWS region"
+  type        = string
+  default     = "us-west-2"
+}
+
+variable "name_prefix" {
+  description = "Prefix for all resource names"
+  type        = string
+  default     = "devonn-vpc-prod"
+}
+
+variable "cluster_name" {
+  description = "EKS cluster name"
+  type        = string
+  default     = "devonn-eks-prod"
+}
+
+variable "vpc_cidr" {
+  description = "VPC CIDR block"
+  type        = string
+  default     = "10.0.0.0/16"
+}
+
+variable "az_count" {
+  description = "Number of availability zones"
+  type        = number
+  default     = 2
+}
+
+variable "node_desired" {
+  description = "Desired number of EKS nodes"
+  type        = number
+  default     = 2
+}
+
+variable "node_min" {
+  description = "Minimum number of EKS nodes"
+  type        = number
+  default     = 1
+}
+
+variable "node_max" {
+  description = "Maximum number of EKS nodes"
+  type        = number
+  default     = 3
+}
+
+variable "node_instance_types" {
+  description = "EC2 instance types for EKS nodes"
+  type        = list(string)
+  default     = ["t3.small"]
+}
+
+variable "tags" {
+  description = "Tags to apply to all resources"
+  type        = map(string)
+  default = {
+    Environment = "prod"
+    ManagedBy   = "terraform"
+    Project     = "devonn-ai"
+    Stack       = "supreme-ai-deployment-hub"
+  }
+}

--- a/terraform/aws/modules/ecr/main.tf
+++ b/terraform/aws/modules/ecr/main.tf
@@ -1,3 +1,29 @@
-resource "aws_ecr_repository" "backend" { name = "${var.name_prefix}-backend" }
-resource "aws_ecr_repository" "frontend" { name = "${var.name_prefix}-frontend" }
-output "repository_urls" { value = { backend = aws_ecr_repository.backend.repository_url frontend = aws_ecr_repository.frontend.repository_url } }
+################################################################################
+# ECR Repository
+# Live: 211125423223.dkr.ecr.us-west-2.amazonaws.com/production/devonn-ai
+################################################################################
+
+resource "aws_ecr_repository" "devonn_ai" {
+  name                 = "production/devonn-ai"
+  image_tag_mutability = "MUTABLE"
+
+  image_scanning_configuration {
+    scan_on_push = true
+  }
+
+  tags = var.tags
+}
+
+################################################################################
+# Outputs
+################################################################################
+
+output "repository_urls" {
+  value = {
+    devonn_ai = aws_ecr_repository.devonn_ai.repository_url
+  }
+}
+
+output "repository_arn" {
+  value = aws_ecr_repository.devonn_ai.arn
+}

--- a/terraform/aws/modules/ecr/variables.tf
+++ b/terraform/aws/modules/ecr/variables.tf
@@ -1,0 +1,10 @@
+variable "name_prefix" {
+  description = "Prefix for resource names"
+  type        = string
+}
+
+variable "tags" {
+  description = "Tags to apply to all resources"
+  type        = map(string)
+  default     = {}
+}

--- a/terraform/aws/modules/eks/main.tf
+++ b/terraform/aws/modules/eks/main.tf
@@ -1,4 +1,158 @@
-resource "aws_eks_cluster" "this" { name = var.cluster_name role_arn = aws_iam_role.eks.arn vpc_config { subnet_ids = var.subnet_ids } }
-resource "aws_iam_role" "eks" { name = "${var.name_prefix}-eks-role" assume_role_policy = "{}" }
-output "cluster_name" { value = aws_eks_cluster.this.name }
-output "cluster_endpoint" { value = aws_eks_cluster.this.endpoint }
+################################################################################
+# EKS Cluster
+################################################################################
+
+resource "aws_eks_cluster" "this" {
+  name     = var.cluster_name
+  role_arn = aws_iam_role.cluster.arn
+  version  = var.kubernetes_version
+
+  vpc_config {
+    subnet_ids              = var.subnet_ids
+    endpoint_private_access = true
+    endpoint_public_access  = true
+  }
+
+  access_config {
+    authentication_mode = "API"
+  }
+
+  tags = var.tags
+
+  depends_on = [
+    aws_iam_role_policy_attachment.cluster_policy,
+  ]
+}
+
+################################################################################
+# Cluster IAM Role
+################################################################################
+
+resource "aws_iam_role" "cluster" {
+  name = "${var.name_prefix}-eks-cluster-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Action    = "sts:AssumeRole"
+      Effect    = "Allow"
+      Principal = { Service = "eks.amazonaws.com" }
+    }]
+  })
+
+  tags = var.tags
+}
+
+resource "aws_iam_role_policy_attachment" "cluster_policy" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKSClusterPolicy"
+  role       = aws_iam_role.cluster.name
+}
+
+################################################################################
+# Node Group IAM Role
+################################################################################
+
+resource "aws_iam_role" "node_group" {
+  name = "${var.name_prefix}-eks-node-group-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Action    = "sts:AssumeRole"
+      Effect    = "Allow"
+      Principal = { Service = "ec2.amazonaws.com" }
+    }]
+  })
+
+  tags = var.tags
+}
+
+resource "aws_iam_role_policy_attachment" "node_worker_policy" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy"
+  role       = aws_iam_role.node_group.name
+}
+
+resource "aws_iam_role_policy_attachment" "node_cni_policy" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy"
+  role       = aws_iam_role.node_group.name
+}
+
+resource "aws_iam_role_policy_attachment" "node_ecr_policy" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"
+  role       = aws_iam_role.node_group.name
+}
+
+################################################################################
+# Launch Template
+################################################################################
+
+resource "aws_launch_template" "node_group" {
+  name = "${var.name_prefix}-eks-node-lt"
+
+  metadata_options {
+    http_endpoint               = "enabled"
+    http_tokens                 = "required"
+    http_put_response_hop_limit = 2
+  }
+
+  tag_specifications {
+    resource_type = "instance"
+    tags = merge(var.tags, {
+      Name = "${var.name_prefix}-eks-node"
+    })
+  }
+
+  tags = var.tags
+}
+
+################################################################################
+# EKS Node Group
+################################################################################
+
+resource "aws_eks_node_group" "this" {
+  cluster_name    = aws_eks_cluster.this.name
+  node_group_name = "${var.name_prefix}-nodes-v2"
+  node_role_arn   = aws_iam_role.node_group.arn
+  subnet_ids      = var.subnet_ids
+  ami_type        = "AL2023_x86_64_STANDARD"
+  instance_types  = var.instance_types
+
+  scaling_config {
+    desired_size = var.desired_capacity
+    max_size     = var.max_capacity
+    min_size     = var.min_capacity
+  }
+
+  launch_template {
+    id      = aws_launch_template.node_group.id
+    version = aws_launch_template.node_group.latest_version
+  }
+
+  tags = var.tags
+
+  depends_on = [
+    aws_iam_role_policy_attachment.node_worker_policy,
+    aws_iam_role_policy_attachment.node_cni_policy,
+    aws_iam_role_policy_attachment.node_ecr_policy,
+  ]
+}
+
+################################################################################
+# Outputs
+################################################################################
+
+output "cluster_name" {
+  value = aws_eks_cluster.this.name
+}
+
+output "cluster_endpoint" {
+  value = aws_eks_cluster.this.endpoint
+}
+
+output "cluster_ca_certificate" {
+  value = aws_eks_cluster.this.certificate_authority[0].data
+}
+
+output "node_group_role_arn" {
+  value = aws_iam_role.node_group.arn
+}

--- a/terraform/aws/modules/eks/variables.tf
+++ b/terraform/aws/modules/eks/variables.tf
@@ -1,0 +1,55 @@
+variable "name_prefix" {
+  description = "Prefix for all resource names"
+  type        = string
+}
+
+variable "cluster_name" {
+  description = "EKS cluster name"
+  type        = string
+}
+
+variable "subnet_ids" {
+  description = "List of subnet IDs for the cluster and node group"
+  type        = list(string)
+}
+
+variable "vpc_id" {
+  description = "VPC ID"
+  type        = string
+}
+
+variable "kubernetes_version" {
+  description = "Kubernetes version"
+  type        = string
+  default     = "1.33"
+}
+
+variable "instance_types" {
+  description = "EC2 instance types for the node group"
+  type        = list(string)
+  default     = ["t3.small"]
+}
+
+variable "desired_capacity" {
+  description = "Desired number of nodes"
+  type        = number
+  default     = 2
+}
+
+variable "min_capacity" {
+  description = "Minimum number of nodes"
+  type        = number
+  default     = 1
+}
+
+variable "max_capacity" {
+  description = "Maximum number of nodes"
+  type        = number
+  default     = 3
+}
+
+variable "tags" {
+  description = "Tags to apply to all resources"
+  type        = map(string)
+  default     = {}
+}


### PR DESCRIPTION
## Summary

- Sync Terraform with manually recreated node group (`devonn-nodes-v2`)
- Add `aws_launch_template` with IMDSv2 hop-limit=2 (fixes DEGRADED node group root cause)
- Fix region: `us-east-1` → `us-west-2`
- Fix cluster name: `devonn-eks` → `devonn-eks-prod`
- Fix ECR module: single repo `production/devonn-ai` (was two incorrect repos)
- Add cluster and node group IAM roles with correct trust policies
- Add `import.sh` with exact `terraform import` commands for all live resources
- Add S3 backend config (commented, ready to enable)
- Add `required_providers` block to prod `main.tf`

## Why

This PR aligns infrastructure state with the live EKS environment after the node group migration. Without this, `terraform plan` would show destructive drift against the live cluster.

## Verification

After merge, run:
```bash
cd terraform/aws/environments/prod
export AWS_PROFILE=devonn-root
export AWS_DEFAULT_REGION=us-west-2
bash import.sh
```