### PR TITLE
feat(hermes): Hermes v2 OPA-based Policy Gate

### DIFF
--- a/.github/workflows/hermes-gate.yml
+++ b/.github/workflows/hermes-gate.yml
@@ -1,0 +1,68 @@
+name: Hermes v2 Policy Gate
+
+# Runs on every PR and push to enforce the Hermes policy rules.
+# Blocks merges that violate security or CI governance policies.
+# See: hermes/core/engine.js for the full decision logic.
+
+on:
+  pull_request:
+    branches: [main, develop]
+  push:
+    branches-ignore:
+      - 'dependabot/**'
+      - 'copilot/**'
+
+concurrency:
+  group: hermes-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  hermes:
+    name: Hermes Policy Gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    permissions:
+      contents: read
+      pull-requests: write   # needed for future PR comment bot
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          # Fetch full history so git diff origin/main...HEAD works correctly
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run Hermes unit tests
+        run: node hermes/tests/hermes.test.cjs
+
+      - name: Run Hermes Policy Gate
+        id: hermes
+        run: node hermes/core/engine.cjs
+        env:
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_REF_NAME: ${{ github.ref_name }}
+          GITHUB_ACTOR: ${{ github.actor }}
+          GITHUB_EVENT_NAME: ${{ github.event_name }}
+          GITHUB_RUN_ID: ${{ github.run_id }}
+          GITHUB_SHA: ${{ github.sha }}
+
+      - name: Post decision summary
+        if: always()
+        run: |
+          echo "## Hermes Policy Gate" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          if [ "${{ steps.hermes.outcome }}" = "success" ]; then
+            echo "✅ **APPROVED** — All policy checks passed" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "❌ **BLOCKED** — Policy violation detected. See logs above for details." >> $GITHUB_STEP_SUMMARY
+          fi

--- a/hermes/README.md
+++ b/hermes/README.md
@@ -1,0 +1,61 @@
+# Hermes v2 — Policy Gate
+
+Hermes is a deterministic CI policy decision engine for the Devonn.AI platform. It runs on every pull request and push, evaluating the git diff against a set of governance rules before allowing the pipeline to continue.
+
+## Architecture
+
+```
+GitHub Event (push / PR)
+        ↓
+Context Builder  (hermes/context/github-context.js)
+        ↓
+Policy Engine    (hermes/core/opa.js)
+        ↓
+Decision Contract
+   ├── ALLOW  → pipeline continues
+   ├── WARN   → pipeline continues with advisory message
+   └── DENY   → pipeline blocked (exit 1)
+```
+
+## File Structure
+
+| File | Purpose |
+|------|---------|
+| `core/engine.js` | CI entrypoint — builds context, evaluates policy, enforces decision |
+| `core/opa.js` | OPA-style policy evaluator with deterministic fallback rules |
+| `context/github-context.js` | Builds structured context from GitHub Actions environment + git diff |
+| `policies/main.rego` | Main OPA policy bundle |
+| `policies/security.rego` | Security-focused deny rules |
+| `policies/ci.rego` | CI/CD governance rules |
+| `analyzers/secrets.js` | Secret pattern scanner |
+| `analyzers/terraform.js` | Terraform-aware diff analyzer |
+| `analyzers/diff.js` | General-purpose diff metadata parser |
+| `tests/hermes.test.js` | Unit test suite (no external dependencies) |
+
+## Policy Rules
+
+| Rule | Type | Trigger |
+|------|------|---------|
+| Direct push to `main` by human | DENY | `branch == "main"` and actor is not a bot |
+| Secrets in diff | DENY | AWS keys, GitHub PATs, private key headers, etc. |
+| Large infra change | DENY | Terraform files changed AND diff > 8 KB |
+| Small infra change | WARN | Terraform files changed, diff within limit |
+| Workflow file changed | WARN | `.github/workflows/` files modified |
+| Dependency manifest changed | WARN | `package.json`, `requirements.txt`, etc. modified |
+| Everything else | ALLOW | No policy violations detected |
+
+## Running Locally
+
+```bash
+# Run unit tests
+node hermes/tests/hermes.test.js
+
+# Run the full policy gate (uses your local git state)
+node hermes/core/engine.js
+```
+
+## Roadmap
+
+- **v2 (current):** OPA-compatible deterministic policy engine with structured risk signals
+- **v3:** Real OPA WASM runtime, PR comment bot, risk heatmaps, AWS IAM introspection
+- **v4:** Devonn.AI agent execution firewall integration

--- a/hermes/analyzers/diff.cjs
+++ b/hermes/analyzers/diff.cjs
@@ -1,0 +1,48 @@
+"use strict";
+/**
+ * hermes/analyzers/diff.js
+ *
+ * General-purpose diff analyzer for Hermes v2.
+ * Provides structured metadata about a git diff for use by the policy engine.
+ */
+
+/**
+ * Parse a unified diff string into structured metadata.
+ *
+ * @param {string} diff - The git diff string
+ * @returns {object} Structured diff metadata
+ */
+function analyzeDiff(diff) {
+  const lines = diff.split("\n");
+
+  let additions = 0;
+  let deletions = 0;
+  const filesChanged = new Set();
+
+  for (const line of lines) {
+    if (line.startsWith("+++ b/")) {
+      filesChanged.add(line.replace("+++ b/", "").trim());
+    } else if (line.startsWith("+") && !line.startsWith("+++")) {
+      additions++;
+    } else if (line.startsWith("-") && !line.startsWith("---")) {
+      deletions++;
+    }
+  }
+
+  const totalChanges = additions + deletions;
+  const churnRatio = deletions > 0 ? additions / deletions : additions;
+
+  return {
+    filesChanged: [...filesChanged],
+    fileCount: filesChanged.size,
+    additions,
+    deletions,
+    totalChanges,
+    diffSize: diff.length,
+    churnRatio: Math.round(churnRatio * 100) / 100,
+    isLarge: diff.length > 8000,
+    isEmpty: diff.trim().length === 0,
+  };
+}
+
+module.exports = { analyzeDiff };

--- a/hermes/analyzers/secrets.cjs
+++ b/hermes/analyzers/secrets.cjs
@@ -1,0 +1,49 @@
+"use strict";
+/**
+ * hermes/analyzers/secrets.js
+ *
+ * Secret pattern analyzer for Hermes v2.
+ * Scans a diff string for known secret patterns and returns structured findings.
+ *
+ * Pattern coverage:
+ *   - AWS Access Key IDs (AKIA...)
+ *   - Generic API tokens and secrets
+ *   - Passwords in assignment form
+ *   - Private key headers (RSA, EC, OpenSSH)
+ *   - GitHub PATs (ghp_...)
+ *   - Stripe keys (sk_live_...)
+ *   - Supabase service role keys (eyJ... JWT pattern)
+ */
+
+const SECRET_PATTERNS = [
+  { name: "AWS Access Key",    pattern: /AKIA[0-9A-Z]{16}/g },
+  { name: "GitHub PAT",        pattern: /ghp_[a-zA-Z0-9]{36}/g },
+  { name: "Stripe Secret Key", pattern: /sk_live_[a-zA-Z0-9]{24,}/g },
+  { name: "Private Key Header",pattern: /-----BEGIN (RSA|EC|OPENSSH|DSA) PRIVATE KEY-----/g },
+  { name: "Generic Secret",    pattern: /(?:SECRET|API_KEY|PRIVATE_KEY)\s*=\s*["']?[a-zA-Z0-9+/=_\-]{16,}/gi },
+  { name: "Generic Password",  pattern: /(?:PASSWORD|PASSWD)\s*=\s*["']?[^\s"']{8,}/gi },
+];
+
+/**
+ * Scan a diff string for secret patterns.
+ *
+ * @param {string} diff - The git diff string to scan
+ * @returns {{ found: boolean, findings: Array<{ name: string, count: number }> }}
+ */
+function scanForSecrets(diff) {
+  const findings = [];
+
+  for (const { name, pattern } of SECRET_PATTERNS) {
+    const matches = diff.match(pattern);
+    if (matches && matches.length > 0) {
+      findings.push({ name, count: matches.length });
+    }
+  }
+
+  return {
+    found: findings.length > 0,
+    findings,
+  };
+}
+
+module.exports = { scanForSecrets };

--- a/hermes/analyzers/terraform.cjs
+++ b/hermes/analyzers/terraform.cjs
@@ -1,0 +1,52 @@
+"use strict";
+/**
+ * hermes/analyzers/terraform.js
+ *
+ * Terraform-aware diff analyzer for Hermes v2.
+ * Detects high-risk infrastructure changes that warrant additional review.
+ */
+
+const HIGH_RISK_RESOURCES = [
+  "aws_iam_role",
+  "aws_iam_policy",
+  "aws_iam_user",
+  "aws_security_group",
+  "aws_vpc",
+  "aws_subnet",
+  "aws_s3_bucket",
+  "aws_rds_instance",
+  "aws_eks_cluster",
+  "aws_kms_key",
+  "google_iam_binding",
+  "azurerm_role_assignment",
+];
+
+/**
+ * Analyze a diff for Terraform-specific risk signals.
+ *
+ * @param {string} diff - The git diff string
+ * @param {string[]} files - List of changed file paths
+ * @returns {{ hasTerraformChanges: boolean, highRiskResources: string[], destroyOperations: boolean }}
+ */
+function analyzeTerraform(diff, files) {
+  const hasTerraformChanges = files.some((f) => /\.(tf|tfvars)$/.test(f));
+
+  if (!hasTerraformChanges) {
+    return { hasTerraformChanges: false, highRiskResources: [], destroyOperations: false };
+  }
+
+  const highRiskResources = HIGH_RISK_RESOURCES.filter((resource) =>
+    diff.includes(`resource "${resource}"`) || diff.includes(`resource '${resource}'`)
+  );
+
+  // Detect `terraform destroy` or `-/+ destroy` patterns in plan output
+  const destroyOperations = /\-\/\+ destroy|will be destroyed|Plan: \d+ to destroy/.test(diff);
+
+  return {
+    hasTerraformChanges,
+    highRiskResources,
+    destroyOperations,
+  };
+}
+
+module.exports = { analyzeTerraform };

--- a/hermes/context/github-context.cjs
+++ b/hermes/context/github-context.cjs
@@ -1,0 +1,121 @@
+"use strict";
+/**
+ * hermes/context/github-context.js
+ *
+ * Builds a deterministic, CI-aware context object from the GitHub Actions
+ * environment and the git diff between the PR branch and origin/main.
+ *
+ * Works correctly in:
+ *   - GitHub Actions pull_request events
+ *   - GitHub Actions push events
+ *   - Local development (falls back gracefully)
+ */
+
+const { execSync } = require("child_process");
+
+/**
+ * Safely execute a shell command and return its stdout as a string.
+ * Returns an empty string on failure rather than throwing.
+ *
+ * @param {string} cmd
+ * @returns {string}
+ */
+function safeExec(cmd) {
+  try {
+    return execSync(cmd, { stdio: ["pipe", "pipe", "pipe"] }).toString();
+  } catch {
+    return "";
+  }
+}
+
+/**
+ * Get the git diff between the current branch and origin/main.
+ * Tries the PR-aware three-dot diff first; falls back to HEAD diff.
+ *
+ * @returns {string}
+ */
+function getDiff() {
+  const prDiff = safeExec("git diff origin/main...HEAD");
+  if (prDiff.trim().length > 0) return prDiff;
+  return safeExec("git diff HEAD");
+}
+
+/**
+ * Extract the list of changed files from a unified diff string.
+ *
+ * @param {string} diff
+ * @returns {string[]}
+ */
+function extractFiles(diff) {
+  return diff
+    .split("\n")
+    .filter((line) => line.startsWith("+++ b/"))
+    .map((line) => line.replace("+++ b/", "").trim())
+    .filter(Boolean);
+}
+
+/**
+ * Compute structured risk signals from the diff and file list.
+ * Returns a plain object — no heuristic float scores, only boolean signals
+ * that can be evaluated deterministically by the policy engine.
+ *
+ * @param {string[]} files
+ * @param {string} diff
+ * @returns {object}
+ */
+function computeRiskSignals(files, diff) {
+  return {
+    // Secret patterns: AWS keys, generic tokens, passwords, private keys
+    hasSecrets: /AKIA[0-9A-Z]{16}|SECRET|PASSWORD|PRIVATE_KEY|-----BEGIN (RSA|EC|OPENSSH)/i.test(diff),
+
+    // Infrastructure changes: Terraform, Kubernetes, Helm, Docker
+    touchesInfra: files.some((f) =>
+      /\.(tf|tfvars|yaml|yml)$/.test(f) &&
+      /terraform|k8s|helm|kubernetes|deploy/i.test(f)
+    ),
+
+    // Dependency manifest changes (supply chain risk)
+    touchesDependencies: files.some((f) =>
+      /package\.json|requirements\.txt|go\.mod|Gemfile|Cargo\.toml/.test(f)
+    ),
+
+    // CI/CD workflow changes
+    touchesWorkflows: files.some((f) => f.includes(".github/workflows/")),
+
+    // Large diff (> 8 KB of changes) — may indicate bulk changes needing review
+    largeDiff: diff.length > 8000,
+
+    // Number of files changed
+    fileCount: files.length,
+  };
+}
+
+/**
+ * Build and return the full Hermes context object.
+ *
+ * @returns {object}
+ */
+function buildContext() {
+  const diff = getDiff();
+  const filesChanged = extractFiles(diff);
+  const riskSignals = computeRiskSignals(filesChanged, diff);
+
+  return {
+    // GitHub Actions environment variables
+    repo: process.env.GITHUB_REPOSITORY || "unknown/unknown",
+    branch: process.env.GITHUB_REF_NAME || safeExec("git branch --show-current").trim() || "unknown",
+    actor: process.env.GITHUB_ACTOR || "unknown",
+    eventName: process.env.GITHUB_EVENT_NAME || "unknown",
+    runId: process.env.GITHUB_RUN_ID || "local",
+    sha: process.env.GITHUB_SHA || safeExec("git rev-parse HEAD").trim().slice(0, 8),
+
+    // Diff analysis
+    filesChanged,
+    diffSize: diff.length,
+
+    // Structured risk signals (used by policy engine)
+    riskSignals,
+  };
+}
+
+module.exports = { buildContext };

--- a/hermes/core/engine.cjs
+++ b/hermes/core/engine.cjs
@@ -1,0 +1,77 @@
+#!/usr/bin/env node
+"use strict";
+/**
+ * hermes/core/engine.js
+ *
+ * Hermes v2 Policy Gate — CI Entrypoint
+ *
+ * Usage:
+ *   node hermes/core/engine.js
+ *
+ * Exit codes:
+ *   0 — ALLOW or WARN (pipeline continues)
+ *   1 — DENY (pipeline blocked)
+ *
+ * Environment variables (set automatically by GitHub Actions):
+ *   GITHUB_REPOSITORY, GITHUB_REF_NAME, GITHUB_ACTOR,
+ *   GITHUB_EVENT_NAME, GITHUB_RUN_ID, GITHUB_SHA
+ */
+
+const { buildContext } = require("../context/github-context.cjs");
+const { evaluateWithOPA } = require("./opa.cjs");
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+(function main() {
+  console.log("╔══════════════════════════════════════════╗");
+  console.log("║        HERMES v2 POLICY GATE             ║");
+  console.log("╚══════════════════════════════════════════╝\n");
+
+  // Step 1: Build context
+  let context;
+  try {
+    context = buildContext();
+  } catch (err) {
+    console.error("❌ HERMES ERROR: Failed to build context:", err.message);
+    process.exit(1);
+  }
+
+  console.log("=== CONTEXT ===");
+  console.log(JSON.stringify(context, null, 2));
+  console.log("");
+
+  // Step 2: Evaluate policy
+  let result;
+  try {
+    result = evaluateWithOPA(context);
+  } catch (err) {
+    console.error("❌ HERMES ERROR: Policy evaluation failed:", err.message);
+    process.exit(1);
+  }
+
+  console.log("=== DECISION ===");
+  console.log(JSON.stringify(result, null, 2));
+  console.log("");
+
+  // Step 3: Enforce decision
+  switch (result.decision) {
+    case "DENY":
+      console.error(`❌ BLOCKED by ${result.policy}: ${result.reason}`);
+      process.exit(1);
+      break;
+
+    case "WARN":
+      console.warn(`⚠️  WARNING from ${result.policy}: ${result.reason}`);
+      console.log("✅ Pipeline continues (WARN is non-blocking)");
+      process.exit(0);
+      break;
+
+    case "ALLOW":
+    default:
+      console.log(`✅ APPROVED by ${result.policy}: ${result.reason}`);
+      process.exit(0);
+      break;
+  }
+})();

--- a/hermes/core/opa.cjs
+++ b/hermes/core/opa.cjs
@@ -1,0 +1,154 @@
+"use strict";
+/**
+ * hermes/core/opa.js
+ *
+ * OPA-style policy evaluation engine for Hermes v2.
+ *
+ * Architecture:
+ *   - Loads policy packs from hermes/policies/
+ *   - Evaluates context against each policy in priority order
+ *   - Returns a single deterministic Decision object
+ *
+ * Decision contract:
+ *   { decision: "ALLOW" | "WARN" | "DENY", reason: string, policy: string }
+ *
+ * Future upgrade path:
+ *   Replace evaluatePolicy() with a real OPA WASM runtime via
+ *   @open-policy-agent/opa-wasm for full Rego evaluation.
+ */
+
+const fs = require("fs");
+const path = require("path");
+
+// ---------------------------------------------------------------------------
+// Decision constructors
+// ---------------------------------------------------------------------------
+
+/**
+ * @param {string} reason
+ * @param {string} policy
+ * @returns {{ decision: "DENY", reason: string, policy: string }}
+ */
+function deny(reason, policy = "unknown") {
+  return { decision: "DENY", reason, policy };
+}
+
+/**
+ * @param {string} reason
+ * @param {string} policy
+ * @returns {{ decision: "WARN", reason: string, policy: string }}
+ */
+function warn(reason, policy = "unknown") {
+  return { decision: "WARN", reason, policy };
+}
+
+/**
+ * @param {string} reason
+ * @param {string} policy
+ * @returns {{ decision: "ALLOW", reason: string, policy: string }}
+ */
+function allow(reason, policy = "unknown") {
+  return { decision: "ALLOW", reason, policy };
+}
+
+// ---------------------------------------------------------------------------
+// Policy rules (deterministic, CI-safe, OPA-compatible structure)
+// ---------------------------------------------------------------------------
+
+/**
+ * Evaluate the context against all policy rules.
+ * Rules are evaluated in priority order: DENY rules first, then WARN, then ALLOW.
+ *
+ * @param {object} ctx - The Hermes context object from buildContext()
+ * @returns {{ decision: string, reason: string, policy: string }}
+ */
+function evaluatePolicy(ctx) {
+  // ── DENY rules (hard blocks) ─────────────────────────────────────────────
+
+  // ci.rego: block direct pushes to main by humans
+  if (
+    ctx.branch === "main" &&
+    ctx.actor !== "github-actions[bot]" &&
+    ctx.actor !== "dependabot[bot]"
+  ) {
+    return deny("Direct pushes to main are blocked — use a PR", "hermes.ci");
+  }
+
+  // security.rego: block any diff containing secret patterns
+  if (ctx.riskSignals.hasSecrets) {
+    return deny(
+      "Secrets or credentials detected in diff — remove before merging",
+      "hermes.security"
+    );
+  }
+
+  // security.rego: block large infra changes (high blast radius)
+  if (ctx.riskSignals.touchesInfra && ctx.riskSignals.largeDiff) {
+    return deny(
+      "Large infrastructure change detected — split into smaller PRs",
+      "hermes.security"
+    );
+  }
+
+  // ── WARN rules (advisory, non-blocking) ──────────────────────────────────
+
+  // infra modification without being a large diff
+  if (ctx.riskSignals.touchesInfra) {
+    return warn(
+      "Infrastructure files modified — ensure Terraform plan has been reviewed",
+      "hermes.ci"
+    );
+  }
+
+  // CI/CD workflow changes
+  if (ctx.riskSignals.touchesWorkflows) {
+    return warn(
+      "GitHub Actions workflow files modified — review for security misconfigurations",
+      "hermes.ci"
+    );
+  }
+
+  // Dependency manifest changes
+  if (ctx.riskSignals.touchesDependencies) {
+    return warn(
+      "Dependency manifests modified — Dependabot and Snyk scans will run",
+      "hermes.ci"
+    );
+  }
+
+  // ── ALLOW ────────────────────────────────────────────────────────────────
+  return allow("All policy checks passed", "hermes.main");
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Load policy metadata from hermes/policies/ (for logging/audit purposes).
+ * In a real OPA WASM setup this would load and compile the .rego files.
+ *
+ * @returns {string[]} list of policy file names
+ */
+function loadPolicyPack() {
+  const policiesDir = path.join(__dirname, "../policies");
+  try {
+    return fs.readdirSync(policiesDir).filter((f) => f.endsWith(".rego"));
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Main entry point: evaluate context and return a Decision.
+ *
+ * @param {object} context - The Hermes context object
+ * @returns {{ decision: string, reason: string, policy: string, policiesLoaded: string[] }}
+ */
+function evaluateWithOPA(context) {
+  const policiesLoaded = loadPolicyPack();
+  const result = evaluatePolicy(context);
+  return { ...result, policiesLoaded };
+}
+
+module.exports = { evaluateWithOPA, deny, warn, allow };

--- a/hermes/policies/ci.rego
+++ b/hermes/policies/ci.rego
@@ -1,0 +1,27 @@
+# hermes/policies/ci.rego
+# CI/CD governance rules for the Hermes policy gate.
+
+package hermes.ci
+
+import future.keywords.if
+
+# Block direct pushes to main by non-bot actors
+deny contains msg if {
+  input.branch == "main"
+  not startswith(input.actor, "github-actions")
+  not startswith(input.actor, "dependabot")
+  msg := "Direct pushes to main are blocked — use a pull request"
+}
+
+# Warn on workflow file modifications (security review required)
+warn contains msg if {
+  input.riskSignals.touchesWorkflows
+  msg := "GitHub Actions workflow files modified — review for security misconfigurations"
+}
+
+# Warn on infrastructure changes
+warn contains msg if {
+  input.riskSignals.touchesInfra
+  not input.riskSignals.largeDiff
+  msg := "Infrastructure files modified — ensure Terraform plan has been reviewed"
+}

--- a/hermes/policies/main.rego
+++ b/hermes/policies/main.rego
@@ -1,0 +1,25 @@
+# hermes/policies/main.rego
+# Main Hermes policy bundle.
+# Evaluated by the OPA engine (or the deterministic fallback in opa.js).
+#
+# Future: compile this with `opa build` and load via @open-policy-agent/opa-wasm
+
+package hermes
+
+import future.keywords.if
+import future.keywords.in
+
+default allow := false
+
+# Allow if no deny rules triggered and no secrets present
+allow if {
+  not input.riskSignals.hasSecrets
+  not blocked_branch
+}
+
+# Block direct pushes to main by humans
+blocked_branch if {
+  input.branch == "main"
+  not startswith(input.actor, "github-actions")
+  not startswith(input.actor, "dependabot")
+}

--- a/hermes/policies/security.rego
+++ b/hermes/policies/security.rego
@@ -1,0 +1,19 @@
+# hermes/policies/security.rego
+# Security-focused deny rules for the Hermes policy gate.
+
+package hermes.security
+
+import future.keywords.if
+
+# Deny any commit containing secret patterns
+deny contains msg if {
+  input.riskSignals.hasSecrets
+  msg := "Secrets or credentials detected in diff — remove before merging"
+}
+
+# Deny large infrastructure changes (high blast radius)
+deny contains msg if {
+  input.riskSignals.touchesInfra
+  input.riskSignals.largeDiff
+  msg := "Large infrastructure change detected — split into smaller PRs"
+}

--- a/hermes/tests/hermes.test.cjs
+++ b/hermes/tests/hermes.test.cjs
@@ -1,0 +1,211 @@
+"use strict";
+/**
+ * hermes/tests/hermes.test.js
+ *
+ * Unit tests for Hermes v2 Policy Gate.
+ * Run with: node hermes/tests/hermes.test.js
+ *
+ * Tests the policy engine in isolation — no GitHub Actions environment needed.
+ */
+
+const { evaluateWithOPA } = require("../core/opa.cjs");
+const { scanForSecrets } = require("../analyzers/secrets.cjs");
+const { analyzeDiff } = require("../analyzers/diff.cjs");
+const { analyzeTerraform } = require("../analyzers/terraform.cjs");
+
+// ---------------------------------------------------------------------------
+// Minimal test harness (no external dependencies)
+// ---------------------------------------------------------------------------
+
+let passed = 0;
+let failed = 0;
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`  ✓ ${name}`);
+    passed++;
+  } catch (err) {
+    console.error(`  ✗ ${name}`);
+    console.error(`    → ${err.message}`);
+    failed++;
+  }
+}
+
+function assert(condition, message) {
+  if (!condition) throw new Error(message || "Assertion failed");
+}
+
+function assertEqual(actual, expected, label = "") {
+  if (actual !== expected) {
+    throw new Error(`${label}: expected "${expected}", got "${actual}"`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Policy engine tests
+// ---------------------------------------------------------------------------
+
+console.log("\n=== Policy Engine Tests ===");
+
+test("DENY: direct push to main by human", () => {
+  const ctx = {
+    branch: "main",
+    actor: "wesship",
+    riskSignals: { hasSecrets: false, touchesInfra: false, largeDiff: false, touchesWorkflows: false, touchesDependencies: false },
+  };
+  const result = evaluateWithOPA(ctx);
+  assertEqual(result.decision, "DENY", "decision");
+  assert(result.policy === "hermes.ci", "policy should be hermes.ci");
+});
+
+test("ALLOW: push to main by github-actions bot", () => {
+  const ctx = {
+    branch: "main",
+    actor: "github-actions[bot]",
+    riskSignals: { hasSecrets: false, touchesInfra: false, largeDiff: false, touchesWorkflows: false, touchesDependencies: false },
+  };
+  const result = evaluateWithOPA(ctx);
+  assertEqual(result.decision, "ALLOW", "decision");
+});
+
+test("DENY: secrets in diff", () => {
+  const ctx = {
+    branch: "feature/my-feature",
+    actor: "wesship",
+    riskSignals: { hasSecrets: true, touchesInfra: false, largeDiff: false, touchesWorkflows: false, touchesDependencies: false },
+  };
+  const result = evaluateWithOPA(ctx);
+  assertEqual(result.decision, "DENY", "decision");
+  assert(result.policy === "hermes.security", "policy should be hermes.security");
+});
+
+test("DENY: large infra change", () => {
+  const ctx = {
+    branch: "feature/infra-overhaul",
+    actor: "wesship",
+    riskSignals: { hasSecrets: false, touchesInfra: true, largeDiff: true, touchesWorkflows: false, touchesDependencies: false },
+  };
+  const result = evaluateWithOPA(ctx);
+  assertEqual(result.decision, "DENY", "decision");
+});
+
+test("WARN: small infra change", () => {
+  const ctx = {
+    branch: "feature/add-sg-rule",
+    actor: "wesship",
+    riskSignals: { hasSecrets: false, touchesInfra: true, largeDiff: false, touchesWorkflows: false, touchesDependencies: false },
+  };
+  const result = evaluateWithOPA(ctx);
+  assertEqual(result.decision, "WARN", "decision");
+});
+
+test("WARN: workflow file changed", () => {
+  const ctx = {
+    branch: "feature/fix-ci",
+    actor: "wesship",
+    riskSignals: { hasSecrets: false, touchesInfra: false, largeDiff: false, touchesWorkflows: true, touchesDependencies: false },
+  };
+  const result = evaluateWithOPA(ctx);
+  assertEqual(result.decision, "WARN", "decision");
+});
+
+test("ALLOW: clean feature branch", () => {
+  const ctx = {
+    branch: "feature/add-dashboard",
+    actor: "wesship",
+    riskSignals: { hasSecrets: false, touchesInfra: false, largeDiff: false, touchesWorkflows: false, touchesDependencies: false },
+  };
+  const result = evaluateWithOPA(ctx);
+  assertEqual(result.decision, "ALLOW", "decision");
+});
+
+// ---------------------------------------------------------------------------
+// Secrets analyzer tests
+// ---------------------------------------------------------------------------
+
+console.log("\n=== Secrets Analyzer Tests ===");
+
+test("detects AWS access key", () => {
+  const diff = "+AWS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE";
+  const result = scanForSecrets(diff);
+  assert(result.found, "should find AWS key");
+  assert(result.findings.some((f) => f.name === "AWS Access Key"), "should name it");
+});
+
+test("detects GitHub PAT", () => {
+  const diff = "+TOKEN=ghp_abcdefghijklmnopqrstuvwxyz1234567890";
+  const result = scanForSecrets(diff);
+  assert(result.found, "should find GitHub PAT");
+});
+
+test("detects private key header", () => {
+  const diff = "+-----BEGIN RSA PRIVATE KEY-----";
+  const result = scanForSecrets(diff);
+  assert(result.found, "should find private key");
+});
+
+test("clean diff returns no findings", () => {
+  const diff = "+const greeting = 'hello world';";
+  const result = scanForSecrets(diff);
+  assert(!result.found, "should not find secrets in clean diff");
+  assertEqual(result.findings.length, 0, "findings count");
+});
+
+// ---------------------------------------------------------------------------
+// Diff analyzer tests
+// ---------------------------------------------------------------------------
+
+console.log("\n=== Diff Analyzer Tests ===");
+
+test("parses additions and deletions", () => {
+  const diff = `--- a/src/app.ts\n+++ b/src/app.ts\n+const x = 1;\n-const y = 2;\n+const z = 3;`;
+  const result = analyzeDiff(diff);
+  assertEqual(result.additions, 2, "additions");
+  assertEqual(result.deletions, 1, "deletions");
+  assertEqual(result.fileCount, 1, "fileCount");
+});
+
+test("detects large diff", () => {
+  const diff = "+" + "x".repeat(9000);
+  const result = analyzeDiff(diff);
+  assert(result.isLarge, "should be large");
+});
+
+test("detects empty diff", () => {
+  const result = analyzeDiff("");
+  assert(result.isEmpty, "should be empty");
+});
+
+// ---------------------------------------------------------------------------
+// Terraform analyzer tests
+// ---------------------------------------------------------------------------
+
+console.log("\n=== Terraform Analyzer Tests ===");
+
+test("detects terraform changes", () => {
+  const files = ["infrastructure/main.tf", "src/app.ts"];
+  const diff = `+resource "aws_iam_role" "my_role" {}`;
+  const result = analyzeTerraform(diff, files);
+  assert(result.hasTerraformChanges, "should detect terraform");
+  assert(result.highRiskResources.includes("aws_iam_role"), "should flag iam_role");
+});
+
+test("no terraform changes", () => {
+  const files = ["src/app.ts", "README.md"];
+  const result = analyzeTerraform("", files);
+  assert(!result.hasTerraformChanges, "should not detect terraform");
+});
+
+// ---------------------------------------------------------------------------
+// Summary
+// ---------------------------------------------------------------------------
+
+console.log(`\n${"─".repeat(44)}`);
+console.log(`Results: ${passed} passed, ${failed} failed`);
+console.log(`${"─".repeat(44)}\n`);
+
+if (failed > 0) {
+  process.exit(1);
+}
+process.exit(0);


### PR DESCRIPTION
## Hermes v2 — OPA-Based CI Policy Gate

Closes #108

### What this PR adds

Hermes v2 is a deterministic CI policy decision engine that runs on every PR and push, evaluating the git diff against governance rules before allowing the pipeline to continue.

### Architecture

```
GitHub Event (push / PR)
        ↓
Context Builder  (hermes/context/github-context.cjs)
        ↓
Policy Engine    (hermes/core/opa.cjs)
        ↓
Decision Contract
   ├── ALLOW  → pipeline continues
   ├── WARN   → pipeline continues with advisory
   └── DENY   → pipeline blocked (exit 1)
```

### Policy Rules

| Rule | Type | Trigger |
|------|------|---------|
| Direct push to `main` by human | DENY | branch == main and actor is not a bot |
| Secrets in diff | DENY | AWS keys, GitHub PATs, private key headers |
| Large infra change | DENY | Terraform files changed AND diff > 8 KB |
| Small infra change | WARN | Terraform files changed, diff within limit |
| Workflow file changed | WARN | `.github/workflows/` files modified |
| Dependency manifest changed | WARN | `package.json`, `requirements.txt` modified |
| Everything else | ALLOW | No violations detected |

### Test Results

16/16 unit tests passing (policy engine, secrets analyzer, diff analyzer, terraform analyzer)

### Files Added

- `hermes/core/engine.cjs` — CI entrypoint
- `hermes/core/opa.cjs` — OPA-style policy evaluator
- `hermes/context/github-context.cjs` — GitHub Actions context builder
- `hermes/policies/main.rego` — Main OPA policy bundle
- `hermes/policies/security.rego` — Security deny rules
- `hermes/policies/ci.rego` — CI governance rules
- `hermes/analyzers/secrets.cjs` — Secret pattern scanner
- `hermes/analyzers/terraform.cjs` — Terraform risk analyzer
- `hermes/analyzers/diff.cjs` — Diff metadata parser
- `hermes/tests/hermes.test.cjs` — 16-test unit suite
- `hermes/README.md` — Full documentation
- `.github/workflows/hermes-gate.yml` — CI workflow