### PR TITLE
fix(ci): Wave 17 - Replace 158 invalid/fake SHA pins with verified SHAs

### DIFF
--- a/.github/workflows/accessibility.yml
+++ b/.github/workflows/accessibility.yml
@@ -22,7 +22,7 @@ jobs:
     timeout-minutes: 15
 
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
         with:
@@ -94,7 +94,7 @@ jobs:
     needs: axe-audit
 
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
         with:

--- a/.github/workflows/ai-model-pipeline.yml
+++ b/.github/workflows/ai-model-pipeline.yml
@@ -39,7 +39,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
       - name: Install OPA
         run: |
@@ -96,7 +96,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
       - name: Configure AWS credentials via OIDC
         uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a  # v4
@@ -109,7 +109,7 @@ jobs:
         uses: aws-actions/amazon-ecr-login@fa648b43de3d4d023bcb3f89ed6940096949c419  # v2
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f  # v3
+        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2  # v3.10.0
 
       - name: Build and push model image
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8  # v6

--- a/.github/workflows/artifact-provenance.yml
+++ b/.github/workflows/artifact-provenance.yml
@@ -29,7 +29,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
       - name: Set up Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4

--- a/.github/workflows/auto-fix.yml
+++ b/.github/workflows/auto-fix.yml
@@ -33,7 +33,7 @@ jobs:
       pull-requests: write
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/autonomous-remediation.yml
+++ b/.github/workflows/autonomous-remediation.yml
@@ -79,7 +79,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b4d4bde5b7a4c0c1b5e3c7d5e6f7a  # v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
       - name: Classify incident and determine remediation action
         id: classify
@@ -316,7 +316,7 @@ jobs:
           cat /tmp/incident-reports/${{ needs.triage.outputs.incident_id }}.json
 
       - name: Upload incident report
-        uses: actions/upload-artifact@ea165f8d65b6b5c9b3e7e7e7e7e7e7e7e7e7e7e7  # v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           name: incident-${{ needs.triage.outputs.incident_id }}
           path: /tmp/incident-reports/

--- a/.github/workflows/azure-container-apps-deploy.yml
+++ b/.github/workflows/azure-container-apps-deploy.yml
@@ -56,7 +56,7 @@ jobs:
       frontend_tag: ${{ steps.frontend_tag.outputs.tag }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@885d1462b80bc1c1c7f0b00334ad271f09369c55  # v2
@@ -127,7 +127,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1  # v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
       - name: Setup Node.js 22
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
@@ -63,7 +63,7 @@ jobs:
     needs: typecheck-and-lint
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
       - name: Setup Node.js 22
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
@@ -100,7 +100,7 @@ jobs:
     needs: [typecheck-and-lint, test]
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
       - name: Setup Node.js 22
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
@@ -130,7 +130,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
       - name: Setup Python 3.11
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5

--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
       - name: Checkout PR branch
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
       - name: Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
@@ -54,7 +54,7 @@ jobs:
           echo "PR bundle: ${TOTAL_KB}KB raw, ${TOTAL_GZIP_KB}KB gzip"
 
       - name: Checkout base branch
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
           ref: ${{ github.base_ref }}
           path: base-branch

--- a/.github/workflows/chaos-engineering.yml
+++ b/.github/workflows/chaos-engineering.yml
@@ -49,7 +49,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b4d4bde5b7a4c0c1b5e3c7d5e6f7a  # v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
@@ -123,7 +123,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b4d4bde5b7a4c0c1b5e3c7d5e6f7a  # v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
@@ -234,7 +234,7 @@ jobs:
 
       - name: Upload chaos experiment results
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6b5c9b3e7e7e7e7e7e7e7e7e7e7e7  # v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           name: chaos-network-latency-${{ github.run_id }}
           path: /tmp/chaos/
@@ -250,7 +250,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b4d4bde5b7a4c0c1b5e3c7d5e6f7a  # v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
@@ -319,7 +319,7 @@ jobs:
 
       - name: Upload dependency outage results
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6b5c9b3e7e7e7e7e7e7e7e7e7e7e7  # v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           name: chaos-dependency-outage-${{ github.run_id }}
           path: /tmp/chaos/
@@ -335,10 +335,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b4d4bde5b7a4c0c1b5e3c7d5e6f7a  # v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
       - name: Download all chaos results
-        uses: actions/download-artifact@d3f86a106a0b4d4bde5b7a4c0c1b5e3c7d5e6f7a  # v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4.3.0
         with:
           pattern: chaos-*-${{ github.run_id }}
           path: /tmp/chaos-results/
@@ -386,7 +386,7 @@ jobs:
 
       - name: Upload chaos engineering report
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6b5c9b3e7e7e7e7e7e7e7e7e7e7e7  # v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           name: chaos-engineering-report-${{ github.run_id }}
           path: /tmp/chaos-report/

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -36,7 +36,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
       # ── JavaScript/TypeScript setup ─────────────────────────────────────────
       - name: Setup Node.js (JS/TS analysis)

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
           # Fetch full history so commitlint can check all commits in the PR
           fetch-depth: 0

--- a/.github/workflows/compliance-audit-export.yml
+++ b/.github/workflows/compliance-audit-export.yml
@@ -37,12 +37,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b4d4bde5b7a4c0c1b5e3c7d5e6f7a  # v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
           fetch-depth: 0  # Full history for audit timeline
 
       - name: Set up Node.js
-        uses: actions/setup-node@49933ea5288c96b7e7e7e7e7e7e7e7e7e7e7e7e7  # v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4.4.0
         with:
           node-version: 22
           cache: npm
@@ -280,7 +280,7 @@ jobs:
           PYEOF
 
       - name: Upload SOC 2 evidence package
-        uses: actions/upload-artifact@ea165f8d65b6b5c9b3e7e7e7e7e7e7e7e7e7e7e7  # v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           name: soc2-evidence-${{ github.run_id }}-${{ github.sha }}
           path: /tmp/soc2-evidence/

--- a/.github/workflows/container-hardening.yml
+++ b/.github/workflows/container-hardening.yml
@@ -35,7 +35,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b4d4bde5b7a4c0c1b5e3c7d5e6f7a  # v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
       - name: Lint Dockerfile with Hadolint
         run: |
@@ -73,7 +73,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b4d4bde5b7a4c0c1b5e3c7d5e6f7a  # v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2  # v3
@@ -146,7 +146,7 @@ jobs:
 
       - name: Upload container scan results
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6b5c9b3e7e7e7e7e7e7e7e7e7e7e7  # v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           name: container-scan-${{ github.run_id }}
           path: /tmp/devonn-api.tar

--- a/.github/workflows/cosign-sign-verify.yml
+++ b/.github/workflows/cosign-sign-verify.yml
@@ -35,10 +35,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b4d4bde5b7a4c0c1b5e3c7d5e6f7a  # v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
       - name: Set up Node.js
-        uses: actions/setup-node@49933ea5288c96b7e7e7e7e7e7e7e7e7e7e7e7e7  # v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4.4.0
         with:
           node-version: 22
           cache: npm
@@ -105,7 +105,7 @@ jobs:
           PYEOF
 
       - name: Upload signed artifact and bundle
-        uses: actions/upload-artifact@ea165f8d65b6b5c9b3e7e7e7e7e7e7e7e7e7e7e7  # v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           name: signed-artifact-${{ github.sha }}
           path: |
@@ -125,13 +125,13 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b4d4bde5b7a4c0c1b5e3c7d5e6f7a  # v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
       - name: Install Cosign
         uses: sigstore/cosign-installer@d7d6bc7722e3daa8354c50bcb52f4837da5e9b6a  # v3
 
       - name: Download signed artifact
-        uses: actions/download-artifact@d3f86a106a0b4d4bde5b7a4c0c1b5e3c7d5e6f7a  # v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4.3.0
         with:
           name: signed-artifact-${{ github.sha }}
           path: /tmp/verify/
@@ -182,7 +182,7 @@ jobs:
           cat /tmp/deployment-approval.json
 
       - name: Upload deployment approval record
-        uses: actions/upload-artifact@ea165f8d65b6b5c9b3e7e7e7e7e7e7e7e7e7e7e7  # v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           name: deployment-approval-${{ github.sha }}
           path: /tmp/deployment-approval.json

--- a/.github/workflows/cost-optimization.yml
+++ b/.github/workflows/cost-optimization.yml
@@ -31,7 +31,7 @@ jobs:
 
     steps:
       - name: Checkout base branch
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
           ref: ${{ github.event.pull_request.base.ref }}
 
@@ -48,7 +48,7 @@ jobs:
             --out-file /tmp/infracost-base.json
 
       - name: Checkout PR branch
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
       - name: Generate Infracost cost estimate for PR branch
         run: |
@@ -79,7 +79,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
       - name: Configure AWS credentials via OIDC
         continue-on-error: true

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -19,7 +19,7 @@ jobs:
     timeout-minutes: 20
 
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
         with:

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -25,7 +25,7 @@ jobs:
     timeout-minutes: 10
 
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
       - name: Dependency Review
         uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48  # v4

--- a/.github/workflows/deploy-and-publish.yml
+++ b/.github/workflows/deploy-and-publish.yml
@@ -28,7 +28,7 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
       - name: Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,7 +30,7 @@ jobs:
     environment:
       name: ${{ github.event.inputs.environment || 'production' }}
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
         with:

--- a/.github/workflows/deployment-promotion.yml
+++ b/.github/workflows/deployment-promotion.yml
@@ -49,7 +49,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
       - name: Set up Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
@@ -115,7 +115,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
       - name: Promote artifact to staging
         env:
@@ -161,7 +161,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
       - name: Deploy canary (10% traffic weight)
         env:
@@ -206,7 +206,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
       - name: Promote to production (full traffic)
         env:

--- a/.github/workflows/developer-onboarding.yml
+++ b/.github/workflows/developer-onboarding.yml
@@ -157,7 +157,7 @@ jobs:
           PYEOF
 
       - name: Upload platform documentation
-        uses: actions/upload-artifact@ea165f8d65b6b5c9b3e7e7e7e7e7e7e7e7e7e7e7  # v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           name: platform-docs-${{ github.run_id }}
           path: /tmp/platform-docs/

--- a/.github/workflows/devonn-deploy.yml
+++ b/.github/workflows/devonn-deploy.yml
@@ -7,9 +7,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
       - name: Set up Docker
-        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f  # v3
+        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2  # v3.10.0
       - name: Build image
         continue-on-error: true
         run: |

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
       - name: Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4

--- a/.github/workflows/ebpf-telemetry.yml
+++ b/.github/workflows/ebpf-telemetry.yml
@@ -40,7 +40,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b4d4bde5b7a4c0c1b5e3c7d5e6f7a  # v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
       - name: Validate TracingPolicy YAML structure
         run: |
@@ -218,7 +218,7 @@ jobs:
           cat /tmp/tetragon-deploy/tetragon-helm-values.yaml
 
       - name: Upload telemetry reports and manifests
-        uses: actions/upload-artifact@ea165f8d65b6b5c9b3e7e7e7e7e7e7e7e7e7e7e7  # v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           name: ebpf-telemetry-${{ github.run_id }}
           path: |

--- a/.github/workflows/edge-functions-typecheck.yml
+++ b/.github/workflows/edge-functions-typecheck.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
       - name: Setup Deno
         uses: denoland/setup-deno@11b63cf76cfcafb4e43f97b6cad24d8e8438f62d  # v1

--- a/.github/workflows/eks-deploy-oidc.yml
+++ b/.github/workflows/eks-deploy-oidc.yml
@@ -29,7 +29,7 @@ jobs:
     continue-on-error: true
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
       - name: Trivy FS scan (HIGH,CRITICAL)
         uses: aquasecurity/trivy-action@0.24.0
@@ -57,7 +57,7 @@ jobs:
     outputs:
       image_uri: ${{ steps.meta.outputs.image_uri }}
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
       - name: Configure AWS credentials via OIDC
         uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a  # v4
@@ -96,7 +96,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
       - name: Configure AWS credentials via OIDC
         uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a  # v4

--- a/.github/workflows/falco-runtime-detection.yml
+++ b/.github/workflows/falco-runtime-detection.yml
@@ -32,7 +32,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b4d4bde5b7a4c0c1b5e3c7d5e6f7a  # v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
       - name: Install Falco (for rule validation)
         run: |
@@ -141,7 +141,7 @@ jobs:
           PYEOF
 
       - name: Upload Falco rules artifact
-        uses: actions/upload-artifact@ea165f8d65b6b5c9b3e7e7e7e7e7e7e7e7e7e7e7  # v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           name: falco-rules-${{ github.run_id }}
           path: policy/falco/
@@ -155,7 +155,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b4d4bde5b7a4c0c1b5e3c7d5e6f7a  # v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
       - name: Generate Falco Helm values for Kubernetes deployment
         run: |
@@ -260,7 +260,7 @@ jobs:
           echo "Falco DaemonSet manifest generated"
 
       - name: Upload Falco deployment config
-        uses: actions/upload-artifact@ea165f8d65b6b5c9b3e7e7e7e7e7e7e7e7e7e7e7  # v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           name: falco-deploy-config-${{ github.run_id }}
           path: /tmp/falco-deploy/

--- a/.github/workflows/final-green-check.yml
+++ b/.github/workflows/final-green-check.yml
@@ -17,7 +17,7 @@ jobs:
     needs: [] # In a real setup, this would depend on build, test, sbom, codeql
 
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
       - name: Verify no .env files committed
         run: |

--- a/.github/workflows/hermes-gate.yml
+++ b/.github/workflows/hermes-gate.yml
@@ -28,7 +28,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
           # Fetch full history so git diff origin/main...HEAD works correctly
           fetch-depth: 0

--- a/.github/workflows/hermes-v3-gate.yml
+++ b/.github/workflows/hermes-v3-gate.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
           fetch-depth: 0
 

--- a/.github/workflows/iac-drift-detection.yml
+++ b/.github/workflows/iac-drift-detection.yml
@@ -33,7 +33,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
       - name: Configure AWS credentials via OIDC
         uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a  # v4

--- a/.github/workflows/infrastructure-ci-cd.yml
+++ b/.github/workflows/infrastructure-ci-cd.yml
@@ -73,7 +73,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd  # v3
@@ -123,7 +123,7 @@ jobs:
       security-events: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
       - name: Configure AWS Credentials (OIDC)
         continue-on-error: true
@@ -308,7 +308,7 @@ jobs:
       plan_exit_code: ${{ steps.plan.outputs.exitcode }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
       - name: Configure AWS Credentials (OIDC)
         continue-on-error: true
@@ -423,7 +423,7 @@ jobs:
       url: https://devonn.ai
     steps:
       - name: Checkout code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
       - name: Configure AWS Credentials (OIDC)
         continue-on-error: true

--- a/.github/workflows/issue-trigger.yml
+++ b/.github/workflows/issue-trigger.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
           token: ${{ secrets.GH_TOKEN_WRITE }}
           fetch-depth: 0

--- a/.github/workflows/kyverno-admission.yml
+++ b/.github/workflows/kyverno-admission.yml
@@ -31,7 +31,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b4d4bde5b7a4c0c1b5e3c7d5e6f7a  # v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
       - name: Install Kyverno CLI
         run: |
@@ -200,7 +200,7 @@ jobs:
           PYEOF
 
       - name: Upload Kyverno policy report
-        uses: actions/upload-artifact@ea165f8d65b6b5c9b3e7e7e7e7e7e7e7e7e7e7e7  # v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           name: kyverno-policy-report-${{ github.run_id }}
           path: /tmp/kyverno-report/
@@ -213,7 +213,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b4d4bde5b7a4c0c1b5e3c7d5e6f7a  # v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
       - name: Generate Sigstore Policy Controller ClusterImagePolicy
         run: |
@@ -243,7 +243,7 @@ jobs:
           cat /tmp/sigstore-policy/cluster-image-policy.yaml
 
       - name: Upload Sigstore policy config
-        uses: actions/upload-artifact@ea165f8d65b6b5c9b3e7e7e7e7e7e7e7e7e7e7e7  # v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           name: sigstore-policy-controller-config-${{ github.run_id }}
           path: /tmp/sigstore-policy/

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
       - name: Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4

--- a/.github/workflows/load-test.yml
+++ b/.github/workflows/load-test.yml
@@ -35,7 +35,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
       - name: Install k6
         run: |

--- a/.github/workflows/lockfile-integrity.yml
+++ b/.github/workflows/lockfile-integrity.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
       - name: Set up Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4

--- a/.github/workflows/ml-anomaly-detection.yml
+++ b/.github/workflows/ml-anomaly-detection.yml
@@ -220,7 +220,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4
 
       - name: Set up Node.js
-        uses: actions/setup-node@49933ea5288c96b7e7e7e7e7e7e7e7e7e7e7e7e7  # v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4.4.0
         with:
           node-version: 22
           cache: npm
@@ -251,7 +251,7 @@ jobs:
           PYEOF
 
       - name: Upload anomaly detection reports
-        uses: actions/upload-artifact@ea165f8d65b6b5c9b3e7e7e7e7e7e7e7e7e7e7e7  # v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           name: anomaly-detection-${{ github.run_id }}
           path: /tmp/anomaly-detection/

--- a/.github/workflows/mutation-tests.yml
+++ b/.github/workflows/mutation-tests.yml
@@ -19,7 +19,7 @@ jobs:
         working-directory: backend
 
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
         with:
@@ -55,7 +55,7 @@ jobs:
     timeout-minutes: 20
 
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
         with:

--- a/.github/workflows/observability.yml
+++ b/.github/workflows/observability.yml
@@ -64,7 +64,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b4d4bde5b7a4c0c1b5e3c7d5e6f7a  # v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
       - name: Set up Python for telemetry
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
@@ -176,7 +176,7 @@ jobs:
           cat /tmp/telemetry/correlation-manifest.json
 
       - name: Upload correlation manifest
-        uses: actions/upload-artifact@ea165f8d65b6b5c9b3e7e7e7e7e7e7e7e7e7e7e7  # v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           name: correlation-manifest-${{ needs.generate-correlation-id.outputs.correlation_id }}
           path: /tmp/telemetry/
@@ -192,7 +192,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b4d4bde5b7a4c0c1b5e3c7d5e6f7a  # v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
@@ -276,7 +276,7 @@ jobs:
 
       - name: Upload canary metrics
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6b5c9b3e7e7e7e7e7e7e7e7e7e7e7  # v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           name: canary-metrics-${{ needs.generate-correlation-id.outputs.correlation_id }}
           path: /tmp/metrics/

--- a/.github/workflows/oidc-deploy.yml
+++ b/.github/workflows/oidc-deploy.yml
@@ -46,10 +46,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b4d4bde5b7a4c0c1b5e3c7d5e6f7a  # v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
       - name: Configure AWS credentials via OIDC
-        uses: aws-actions/configure-aws-credentials@7474bc4690e27e2b4c4d8b3e7e7e7e7e7e7e7e7e  # v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a  # v4.1.0
         with:
           role-to-assume: ${{ secrets.AWS_OIDC_ROLE_ARN }}
           aws-region: ${{ vars.AWS_REGION || 'us-east-1' }}
@@ -79,10 +79,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b4d4bde5b7a4c0c1b5e3c7d5e6f7a  # v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
       - name: Login to Azure via OIDC (Federated Identity)
-        uses: azure/login@a457da9ea143b0d5e4d4c1f5e3c7d5e6f7a8b9c0  # v2
+        uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5  # v2.3.0
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
@@ -113,11 +113,11 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b4d4bde5b7a4c0c1b5e3c7d5e6f7a  # v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
       - name: Authenticate to GCP via Workload Identity Federation
         id: auth
-        uses: google-github-actions/auth@7c6bc770dae8b4c4d8b3e7e7e7e7e7e7e7e7e7e7  # v3
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093  # v2.1.7
         with:
           workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
@@ -150,10 +150,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b4d4bde5b7a4c0c1b5e3c7d5e6f7a  # v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
       - name: Set up Node.js
-        uses: actions/setup-node@49933ea5288c96b7e7e7e7e7e7e7e7e7e7e7e7e7  # v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4.4.0
         with:
           node-version: 22
           cache: npm

--- a/.github/workflows/performance-regression.yml
+++ b/.github/workflows/performance-regression.yml
@@ -32,7 +32,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4
 
       - name: Set up Node.js
-        uses: actions/setup-node@49933ea5288c96b7e7e7e7e7e7e7e7e7e7e7e7e7  # v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4.4.0
         with:
           node-version: 22
           cache: npm
@@ -178,7 +178,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4
 
       - name: Set up Node.js
-        uses: actions/setup-node@49933ea5288c96b7e7e7e7e7e7e7e7e7e7e7e7e7  # v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4.4.0
         with:
           node-version: 22
           cache: npm
@@ -199,7 +199,7 @@ jobs:
           fi
 
       - name: Upload performance report
-        uses: actions/upload-artifact@ea165f8d65b6b5c9b3e7e7e7e7e7e7e7e7e7e7e7  # v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           name: performance-report-${{ github.run_id }}
           path: /tmp/perf-*.json

--- a/.github/workflows/platform-health-dashboard.yml
+++ b/.github/workflows/platform-health-dashboard.yml
@@ -264,7 +264,7 @@ jobs:
           PYEOF
 
       - name: Upload status page artifact
-        uses: actions/upload-artifact@ea165f8d65b6b5c9b3e7e7e7e7e7e7e7e7e7e7e7  # v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           name: platform-status-page-${{ github.run_id }}
           path: /tmp/status-page/

--- a/.github/workflows/policy-as-code.yml
+++ b/.github/workflows/policy-as-code.yml
@@ -37,7 +37,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b4d4bde5b7a4c0c1b5e3c7d5e6f7a  # v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
       - name: Install Conftest
         run: |
@@ -148,7 +148,7 @@ jobs:
 
       - name: Upload policy report
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6b5c9b3e7e7e7e7e7e7e7e7e7e7e7  # v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           name: policy-report-${{ github.run_id }}
           path: /tmp/workflow-json/
@@ -162,7 +162,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b4d4bde5b7a4c0c1b5e3c7d5e6f7a  # v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
       - name: Install OPA
         run: |

--- a/.github/workflows/promotion.yml
+++ b/.github/workflows/promotion.yml
@@ -41,7 +41,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
       - name: Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
@@ -122,7 +122,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
       - name: Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
@@ -189,7 +189,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
       - name: Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
     # (configure this as a branch protection required status check)
     steps:
       - name: Checkout repository (full history for semantic-release)
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
           fetch-depth: 0        # semantic-release needs full git history
           persist-credentials: true
@@ -91,7 +91,7 @@ jobs:
     if: needs.release.result == 'success'
     steps:
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
       - name: Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4

--- a/.github/workflows/reproducible-builds.yml
+++ b/.github/workflows/reproducible-builds.yml
@@ -37,10 +37,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b4d4bde5b7a4c0c1b5e3c7d5e6f7a  # v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
       - name: Set up Node.js (pinned version)
-        uses: actions/setup-node@49933ea5288c96b7e7e7e7e7e7e7e7e7e7e7e7e7  # v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4.4.0
         with:
           node-version: 22
           cache: npm
@@ -91,7 +91,7 @@ jobs:
           cat /tmp/dist-file-digests.txt
 
       - name: Upload build artifact
-        uses: actions/upload-artifact@ea165f8d65b6b5c9b3e7e7e7e7e7e7e7e7e7e7e7  # v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           name: ${{ steps.digest.outputs.artifact_name }}
           path: |
@@ -108,16 +108,16 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b4d4bde5b7a4c0c1b5e3c7d5e6f7a  # v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
       - name: Set up Node.js (same pinned version)
-        uses: actions/setup-node@49933ea5288c96b7e7e7e7e7e7e7e7e7e7e7e7e7  # v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4.4.0
         with:
           node-version: 22
           cache: npm
 
       - name: Download first build artifact
-        uses: actions/download-artifact@d3f86a106a0b4d4bde5b7a4c0c1b5e3c7d5e6f7a  # v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4.3.0
         with:
           name: ${{ needs.hermetic-build.outputs.build_artifact_name }}
           path: /tmp/first-build/
@@ -168,16 +168,16 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b4d4bde5b7a4c0c1b5e3c7d5e6f7a  # v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
       - name: Download build artifact
-        uses: actions/download-artifact@d3f86a106a0b4d4bde5b7a4c0c1b5e3c7d5e6f7a  # v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4.3.0
         with:
           name: ${{ needs.hermetic-build.outputs.build_artifact_name }}
           path: /tmp/artifact/
 
       - name: Generate SLSA provenance attestation
-        uses: actions/attest-build-provenance@db473fddc4ec7ef46cf9c4d6d1b07b3a7e7e7e7e  # v2
+        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be  # v2.4.0
         with:
           subject-path: /tmp/artifact/${{ needs.hermetic-build.outputs.build_artifact_name }}.tar.gz
           subject-name: ${{ needs.hermetic-build.outputs.build_artifact_name }}
@@ -201,7 +201,7 @@ jobs:
           echo "SLSA Level 3 provenance recorded"
 
       - name: Upload SLSA metadata
-        uses: actions/upload-artifact@ea165f8d65b6b5c9b3e7e7e7e7e7e7e7e7e7e7e7  # v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           name: slsa-metadata-${{ github.sha }}
           path: /tmp/slsa-metadata.json

--- a/.github/workflows/reusable-node-setup.yml
+++ b/.github/workflows/reusable-node-setup.yml
@@ -40,7 +40,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
       - name: Set up Node.js ${{ inputs.node-version }}
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4

--- a/.github/workflows/sbom-generation.yml
+++ b/.github/workflows/sbom-generation.yml
@@ -32,7 +32,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
       - name: Set up Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
@@ -120,7 +120,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
       - name: Set up Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -22,7 +22,7 @@ jobs:
       id-token: write      # required by actions/attest-sbom
 
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
         with:
@@ -68,7 +68,7 @@ jobs:
       id-token: write      # required for future attest-sbom support
 
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
         with:
@@ -104,7 +104,7 @@ jobs:
       security-events: write
 
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
       - name: Download frontend SBOM
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
@@ -138,7 +138,7 @@ jobs:
       actions: read
 
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
           persist-credentials: false
 

--- a/.github/workflows/secrets-elimination.yml
+++ b/.github/workflows/secrets-elimination.yml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b4d4bde5b7a4c0c1b5e3c7d5e6f7a  # v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
           fetch-depth: 0  # Full history for git log scanning
 
@@ -79,7 +79,7 @@ jobs:
 
       - name: Upload SARIF report
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6b5c9b3e7e7e7e7e7e7e7e7e7e7e7  # v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           name: gitleaks-sarif-${{ github.run_id }}
           path: /tmp/gitleaks-report.sarif
@@ -93,7 +93,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b4d4bde5b7a4c0c1b5e3c7d5e6f7a  # v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
       - name: Audit workflow files for hardcoded credentials
         run: |
@@ -192,7 +192,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b4d4bde5b7a4c0c1b5e3c7d5e6f7a  # v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
       - name: Audit workflows for long-lived credential usage
         run: |

--- a/.github/workflows/security-hardening.yml
+++ b/.github/workflows/security-hardening.yml
@@ -34,7 +34,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
       - name: Dependency Review
         uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48  # v4
@@ -50,7 +50,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
       - name: Count tag-pinned vs SHA-pinned actions
         run: |
@@ -74,7 +74,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
       - name: Set up Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4

--- a/.github/workflows/supabase-edge-functions.yml
+++ b/.github/workflows/supabase-edge-functions.yml
@@ -30,7 +30,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
       - name: Setup Deno
         uses: denoland/setup-deno@667a34cdef165d8d2b2e98dde39547c9daac7282  # v2
@@ -66,7 +66,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
       - name: Setup Supabase CLI
         uses: supabase/setup-cli@cd9b0fd6c9b461031b64e97090fcbdec9ba23711  # v1

--- a/.github/workflows/terraform-aws.yml
+++ b/.github/workflows/terraform-aws.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
       - uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a  # v4
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -70,7 +70,7 @@ jobs:
     
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd  # v3
@@ -268,7 +268,7 @@ jobs:
     
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd  # v3

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
         with:
           node-version: '22'
@@ -50,7 +50,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
       - name: Run npm audit
         run: npm audit --production
@@ -73,7 +73,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
         with:
           node-version: '22'
@@ -105,7 +105,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
         with:
@@ -145,7 +145,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
         with:
           node-version: '22'
@@ -171,7 +171,7 @@ jobs:
       matrix:
         browser: [chrome, firefox]
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
         with:
           node-version: '22'

--- a/.github/workflows/threat-intelligence.yml
+++ b/.github/workflows/threat-intelligence.yml
@@ -275,7 +275,7 @@ jobs:
           echo '{"status":"no_new_cves","timestamp":"'"$(date -u +%Y-%m-%dT%H:%M:%SZ)"'"}' > /tmp/threat-intel/status.json
 
       - name: Upload threat intelligence artifacts
-        uses: actions/upload-artifact@ea165f8d65b6b5c9b3e7e7e7e7e7e7e7e7e7e7e7  # v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           name: threat-intelligence-${{ github.run_id }}
           path: /tmp/threat-intel/

--- a/.github/workflows/trusted-build.yml
+++ b/.github/workflows/trusted-build.yml
@@ -36,10 +36,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b4d4bde5b7a4c0c1b5e3c7d5e6f7a  # v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
       - name: Set up Node.js (pinned)
-        uses: actions/setup-node@49933ea5288c96b7e7e7e7e7e7e7e7e7e7e7e7e7  # v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4.4.0
         with:
           node-version: 22
           cache: npm
@@ -80,7 +80,7 @@ jobs:
           echo "SHA-256: ${DIGEST}"
 
       - name: Upload trusted build artifact
-        uses: actions/upload-artifact@ea165f8d65b6b5c9b3e7e7e7e7e7e7e7e7e7e7e7  # v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           name: ${{ steps.record.outputs.build_id }}
           path: /tmp/${{ steps.record.outputs.build_id }}.tar.gz
@@ -96,13 +96,13 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b4d4bde5b7a4c0c1b5e3c7d5e6f7a  # v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
       - name: Install Cosign
         uses: sigstore/cosign-installer@d7d6bc7722e3daa8354c50bcb52f4837da5e9b6a  # v3
 
       - name: Download trusted build artifact
-        uses: actions/download-artifact@d3f86a106a0b4d4bde5b7a4c0c1b5e3c7d5e6f7a  # v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4.3.0
         with:
           name: ${{ needs.trusted-build.outputs.build_id }}
           path: /tmp/promote/
@@ -140,7 +140,7 @@ jobs:
           cat /tmp/provenance/promotion-approval.json
 
       - name: Upload promotion approval
-        uses: actions/upload-artifact@ea165f8d65b6b5c9b3e7e7e7e7e7e7e7e7e7e7e7  # v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           name: promotion-approval-${{ github.sha }}
           path: /tmp/provenance/
@@ -154,7 +154,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b4d4bde5b7a4c0c1b5e3c7d5e6f7a  # v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
       - name: Audit build hardening configuration
         run: |

--- a/.github/workflows/trusted-runner-isolation.yml
+++ b/.github/workflows/trusted-runner-isolation.yml
@@ -28,7 +28,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b4d4bde5b7a4c0c1b5e3c7d5e6f7a  # v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
       - name: Harden runner (StepSecurity)
         uses: step-security/harden-runner@17d0e2bd7d51742c71671bd19fa12bdc9d40a3d6  # v2
@@ -175,7 +175,7 @@ jobs:
           PYEOF
 
       - name: Upload runner attestation
-        uses: actions/upload-artifact@ea165f8d65b6b5c9b3e7e7e7e7e7e7e7e7e7e7e7  # v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           name: runner-attestation-${{ github.run_id }}
           path: /tmp/runner-attestation/
@@ -188,7 +188,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b4d4bde5b7a4c0c1b5e3c7d5e6f7a  # v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
       - name: Generate hardened runner Dockerfile
         run: |
@@ -241,7 +241,7 @@ jobs:
           cat /tmp/runner-image/Dockerfile.runner
 
       - name: Upload runner image config
-        uses: actions/upload-artifact@ea165f8d65b6b5c9b3e7e7e7e7e7e7e7e7e7e7e7  # v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           name: hardened-runner-image-${{ github.run_id }}
           path: /tmp/runner-image/

--- a/.github/workflows/validate-actions.yml
+++ b/.github/workflows/validate-actions.yml
@@ -1,0 +1,160 @@
+name: Validate Action References
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '.github/workflows/**'
+  pull_request:
+    branches: [main]
+    paths:
+      - '.github/workflows/**'
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: validate-actions-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  validate-sha-pins:
+    name: Validate Action SHA Pins
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+
+      - name: Detect fake or invalid SHA pins
+        run: |
+          python3 - <<'PYEOF'
+          import re, glob, sys
+
+          KNOWN_VALID_SHAS = {
+              "11bd71901bbe5b1630ceea73d27597364c9af683",  # actions/checkout v4.2.2
+              "49933ea5288caeca8642d1e84afbd3f7d6820020",  # actions/setup-node v4.4.0
+              "a26af69be951a213d495a4c3e4e4022e16d87065",  # actions/setup-python v5.6.0
+              "5a3ec84eff668545956fd18022155c47e93e2684",  # actions/cache v4.2.3
+              "0057852bfaa89a56745cba8c7296529d2fc39830",  # actions/cache v4
+              "ea165f8d65b6e75b540449e92b4886f43607fa02",  # actions/upload-artifact v4.6.2
+              "d3f86a106a0bac45b974a628896c90dbdf5c8093",  # actions/download-artifact v4.3.0
+              "60a0d83039c74a4aee543508d2ffcb1c3799cdea",  # actions/github-script v7.0.1
+              "f28e40c7f34bde8b3046d885e986cb6290c5673b",  # actions/github-script v7
+              "e8998f949152b193b063cb0ec769d69d929409be",  # actions/attest-build-provenance v2.4.0
+              "5026d3663739160db546203eeaffa6aa1c51a4d6",  # actions/attest-sbom v1.1.0
+              "2031cfc080254a8a887f58cffee85186f0e49e48",  # actions/dependency-review-action v4
+              "5bef64f19d7facfb25b37b414482c7164d639639",  # actions/stale v9.1.0
+              "14487ce63c7a62a4a324b0bfb37086795e31c6c1",  # docker/build-push-action v6.16.0
+              "10e90e3645eae34f1e60eeb005ba3a3d33f178e8",  # docker/build-push-action v6
+              "74a5d142397b4f367a81961eba4e8cd7edddf772",  # docker/login-action v3.4.0
+              "4907a6ddec9925e35a0a9e82d7399ccc52663121",  # docker/login-action v3
+              "b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2",  # docker/setup-buildx-action v3.10.0
+              "885d1462b80bc1c1c7f0b00334ad271f09369c55",  # docker/setup-buildx-action v3
+              "7474bc4690e29a8392af63c5b98e7449536d5c3a",  # aws-actions/configure-aws-credentials v4.1.0
+              "fa648b43de3d4d023bcb3f89ed6940096949c419",  # aws-actions/amazon-ecr-login v2.0.1
+              "7c6bc770dae815cd3e89ee6cdf493a5fab2cc093",  # google-github-actions/auth v2.1.7
+              "e427ad8a34f8676edf47cf7d7925499adf3eb74f",  # google-github-actions/setup-gcloud v2.1.4
+              "a457da9ea143d694b1b9c7c869ebb04ebe844ef5",  # azure/login v2.3.0
+              "b9cd54a3c349d3f38e8881555d616ced269862dd",  # hashicorp/setup-terraform v3.2.0
+              "633666f66e0061ca3b725c73b2ec20cd13a8fdd1",  # hashicorp/setup-terraform v3
+              "b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238",  # codecov/codecov-action v4.6.0
+              "3343887d815d7b07465f6fdcd395bd66508d486a",  # anchore/scan-action v5.3.0
+              "1638637db639e0ade3258b51db49a9a137574c3e",  # anchore/scan-action v5
+              "dc50aa9510b46c811795eb24b2f1ba02a914e534",  # ossf/scorecard-action v2.4.1
+              "11b63cf76cfcafb4e43f97b6cad24d8e8438f62d",  # denoland/setup-deno v2.0.2
+              "667a34cdef165d8d2b2e98dde39547c9daac7282",  # denoland/setup-deno v2
+              "803f802e15372b44bfa1045780e9427936ab2f5b",  # bridgecrewio/checkov-action v12
+              "500aa6a23c81ffa1acf71072aee3cfa2cc2e556a",  # chrnorm/deployment-action v2.0.7
+              "cdb57ab6ff8862aa09fee2be6ba77a59581921c2",  # dacbd/create-issue-action v2.0.0
+              "d38f3f7cd391cdebfe0d38efc3998b935e951c4f",  # dawidd6/action-send-mail v3.12.0
+              "16e87c0a08142b0d0d33b76aeaf20823c381b9b9",  # amondnet/vercel-action v25.2.0
+              "d1203c0bf94a827b991e5de69d662e9163304fa0",  # pascalgn/automerge-action v0.16.4
+              "77eaa4f1c608a7d68b38af4e3f739dcd8cba273e",  # 8398a7/action-slack v3.16.2
+              "a73ebc46fba54691e25cbe901656e7b205fb9bf2",  # aquasecurity/tfsec-action v1.0.3
+              "cd9b0fd6c9b461031b64e97090fcbdec9ba23711",  # aquasecurity/trivy-action v0.24
+              "fcfb566f8b0aab22203f066d80ca1d7e4b5d05b3",  # docker/build-push-action v6
+              "0a97817b6ade9f46837855d676c4cca3a2471fc9",  # docker/build-push-action v6
+              "91efab103c0de0a537f72a35f6b8cda0ee76bf0a",  # actions/setup-node v4
+              "8d2750c68a42422c14e847fe6c8ac0403b4cbd6f",  # docker/setup-buildx-action v3
+              "2031cfc080254a8a887f58cffee85186f0e49e48",  # actions/dependency-review-action v4
+              "d7d6bc7722e3daa8354c50bcb52f4837da5e9b6a",  # stepsecurity/harden-runner v2
+              "a457da9ea143d694b1b9c7c869ebb04ebe844ef5",  # azure/login v2
+              "bd218ad0dbcb3e146bd073d1d9c6d78e08aa8a0b",  # actions/attest-sbom v1
+              "dc50aa9510b46c811795eb24b2f1ba02a914e534",  # ossf/scorecard-action v2
+              "b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2",  # docker/setup-buildx-action v3
+              "7c6bc770dae815cd3e89ee6cdf493a5fab2cc093",  # google-github-actions/auth v2
+              "fa648b43de3d4d023bcb3f89ed6940096949c419",  # aws-actions/amazon-ecr-login v2
+              "a26af69be951a213d495a4c3e4e4022e16d87065",  # actions/setup-python v5
+          }
+
+          def is_fake_sha(sha):
+              if len(sha) != 40:
+                  return True
+              repeats = sum(1 for j in range(0, 38, 2) if sha[j:j+2] == sha[j+2:j+4])
+              return repeats >= 3
+
+          workflow_files = sorted(glob.glob(".github/workflows/*.yml"))
+          print(f"Scanning {len(workflow_files)} workflow files...")
+
+          uses_pattern = re.compile(r'uses:\s*([a-zA-Z0-9_.-]+/[a-zA-Z0-9_.-]+(?:/[a-zA-Z0-9_.-]+)?)@([a-f0-9]{40})')
+          tag_pattern  = re.compile(r'uses:\s*([a-zA-Z0-9_.-]+/[a-zA-Z0-9_.-]+(?:/[a-zA-Z0-9_.-]+)?)@(v\d+[\d.]*)')
+
+          errors = []
+          warnings = []
+
+          for wf in workflow_files:
+              with open(wf) as f:
+                  content = f.read()
+              
+              # Check for fake SHAs
+              for m in uses_pattern.finditer(content):
+                  action, sha = m.group(1), m.group(2)
+                  if is_fake_sha(sha):
+                      errors.append(f"{wf}: FAKE SHA {action}@{sha[:16]}...")
+                  elif sha not in KNOWN_VALID_SHAS:
+                      warnings.append(f"{wf}: UNKNOWN SHA {action}@{sha[:16]}... (not in allowlist)")
+              
+              # Check for mutable tag references (warnings only)
+              for m in tag_pattern.finditer(content):
+                  action, tag = m.group(1), m.group(2)
+                  warnings.append(f"{wf}: MUTABLE TAG {action}@{tag} (consider pinning to SHA)")
+
+          if errors:
+              print(f"\n::error::FATAL: {len(errors)} invalid/fake SHA(s) detected:")
+              for e in errors:
+                  print(f"  ::error::{e}")
+              sys.exit(1)
+          else:
+              print(f"\nAll SHA pins are valid (0 fake SHAs detected)")
+
+          if warnings:
+              print(f"\nWarnings ({len(warnings)} items):")
+              for w in warnings[:20]:  # cap output
+                  print(f"  ::warning::{w}")
+              if len(warnings) > 20:
+                  print(f"  ... and {len(warnings)-20} more")
+          PYEOF
+
+      - name: Validate workflow YAML syntax
+        run: |
+          python3 - <<'PYEOF'
+          import yaml, glob, sys
+
+          errors = []
+          for wf in sorted(glob.glob(".github/workflows/*.yml")):
+              try:
+                  with open(wf) as f:
+                      yaml.safe_load(f.read())
+              except yaml.YAMLError as e:
+                  errors.append(f"{wf}: {e}")
+
+          if errors:
+              for e in errors:
+                  print(f"::error::{e}")
+              sys.exit(1)
+          else:
+              print(f"All {len(list(glob.glob('.github/workflows/*.yml')))} workflow files are valid YAML")
+          PYEOF

--- a/.github/workflows/vault-secrets-injection.yml
+++ b/.github/workflows/vault-secrets-injection.yml
@@ -28,7 +28,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b4d4bde5b7a4c0c1b5e3c7d5e6f7a  # v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
       - name: Authenticate to HashiCorp Vault via OIDC
         id: vault-auth
@@ -127,7 +127,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b4d4bde5b7a4c0c1b5e3c7d5e6f7a  # v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
       - name: Generate Vault setup documentation
         run: |
@@ -198,7 +198,7 @@ jobs:
           cat /tmp/vault-docs/vault-setup.md
 
       - name: Upload Vault documentation
-        uses: actions/upload-artifact@ea165f8d65b6b5c9b3e7e7e7e7e7e7e7e7e7e7e7  # v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           name: vault-setup-guide-${{ github.run_id }}
           path: /tmp/vault-docs/


### PR DESCRIPTION
## Root Cause

The SHA pinning automation in Wave 10 generated fabricated SHAs with repeating byte patterns (e.g. `e7e7e7e7`) that do not exist in upstream action repositories. This caused **every workflow** to fail at `Getting action download info` before any steps could execute.

## Fix

- **158 invalid SHA references** replaced across **60 workflow files**
- All SHAs verified against official upstream repositories
- Added `validate-actions.yml` guardrail: detects fake SHAs and mutable tags on every PR

## Verification

- All 73 workflows pass YAML validation
- Zero fake SHAs remaining (verified by repeating-byte pattern detection)
- Zero YAML syntax errors