### PR TITLE
Add staging deployment foundation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,15 +1,16 @@
-# .env.example — Copy to .env and fill in your values before running run_all.sh
+# .env.example — Copy to a local env file and fill in your own values.
+# Never commit real credentials.
 
 # ─── Required ────────────────────────────────────────────────────────────────
-GITHUB_TOKEN=ghp_your_token_here
-OPENAI_API_KEY=sk-your_openai_key_here
+GITHUB_TOKEN=replace_with_github_token
+OPENAI_API_KEY=replace_with_openai_api_key
 
 # ─── Devonn Ecosystem ─────────────────────────────────────────────────────────
 ORGANIZATION=wesship
 WORKSPACE_DIR=~/DevonnAI_AutoHealer
 CLONE_PROTOCOL=https                  # https or ssh
 
-# ─── Service URLs (defaults work for Render deployments) ─────────────────────
+# ─── Service URLs (defaults work for staging-style deployments) ──────────────
 ORCHESTRATOR_URL=https://central-orchestrator.onrender.com
 GATEWAY_URL=https://openclaw-gateway-2t9e.onrender.com
 
@@ -17,9 +18,9 @@ GATEWAY_URL=https://openclaw-gateway-2t9e.onrender.com
 POLL_INTERVAL=30                      # seconds between queue polls
 
 # ─── MCP API (supreme-ai-deployment-hub) ─────────────────────────────────────
-JWT_SECRET=your_jwt_secret_here
-DB_USERNAME=your_db_user
-DB_PASSWORD=your_db_password
+JWT_SECRET=replace_with_jwt_secret
+DB_USERNAME=replace_with_db_user
+DB_PASSWORD=replace_with_db_password
 DB_NAME=devonn
 
 # ─── Cloud Providers (optional) ──────────────────────────────────────────────

--- a/.github/workflows/staging-ci.yml
+++ b/.github/workflows/staging-ci.yml
@@ -9,9 +9,7 @@ on:
       - "services/**"
       - "infra/**"
       - "observability/**"
-      - "docs/STAGING_DEPLOYMENT_RUNBOOK.md"
-      - "docs/ENVIRONMENT_VARIABLES.md"
-      - "docs/GUARDRAILS.md"
+      - "docs/**"
       - ".github/workflows/staging-ci.yml"
   workflow_dispatch:
 

--- a/.github/workflows/staging-ci.yml
+++ b/.github/workflows/staging-ci.yml
@@ -38,6 +38,25 @@ jobs:
           test -f docs/ENVIRONMENT_VARIABLES.md
           test -f docs/GUARDRAILS.md
 
+      - name: Create CI-only staging env file
+        shell: bash
+        run: |
+          set -euo pipefail
+          cat > .env.staging.local <<'EOF'
+          POSTGRES_DB=devonn_staging_ci
+          POSTGRES_USER=devonn_ci
+          POSTGRES_PASSWORD=local_ci_only
+          DATABASE_URL=postgresql://devonn_ci:local_ci_only@postgres:5432/devonn_staging_ci
+          REDIS_URL=redis://redis:6379/0
+          QDRANT_URL=http://qdrant:6333
+          ENVIRONMENT=staging
+          AUTONOMY_MODE=guarded
+          EXECUTION_MODE=dry-run
+          API_BASE_URL=http://api:8000
+          VITE_API_BASE_URL=http://localhost:8000
+          VITE_ORCHESTRATOR_URL=http://localhost:7373
+          EOF
+
       - name: Validate Docker Compose syntax
         shell: bash
         run: docker compose -f docker-compose.yml config >/tmp/devonn-compose.yml

--- a/.github/workflows/staging-ci.yml
+++ b/.github/workflows/staging-ci.yml
@@ -1,0 +1,59 @@
+name: Staging CI
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "docker-compose.yml"
+      - "services/**"
+      - "infra/**"
+      - "observability/**"
+      - "docs/STAGING_DEPLOYMENT_RUNBOOK.md"
+      - "docs/ENVIRONMENT_VARIABLES.md"
+      - "docs/GUARDRAILS.md"
+      - ".github/workflows/staging-ci.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  staging-foundation:
+    name: Validate staging foundation
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Validate required foundation files
+        shell: bash
+        run: |
+          set -euo pipefail
+          test -f docker-compose.yml
+          test -f infra/render/render.yaml
+          test -f infra/vercel/staging.md
+          test -f docs/STAGING_SERVICE_MAP.md
+          test -f docs/STAGING_DEPLOYMENT_RUNBOOK.md
+          test -f docs/ENVIRONMENT_VARIABLES.md
+          test -f docs/GUARDRAILS.md
+
+      - name: Validate Docker Compose syntax
+        shell: bash
+        run: docker compose -f docker-compose.yml config >/tmp/devonn-compose.yml
+
+      - name: Validate no committed staging env file
+        shell: bash
+        run: |
+          set -euo pipefail
+          if git ls-files | grep -E '^\.env\.staging\.local$'; then
+            echo "Do not commit .env.staging.local"
+            exit 1
+          fi
+
+      - name: Validate guardrail defaults
+        shell: bash
+        run: |
+          set -euo pipefail
+          grep -R "dry-run" docs infra docker-compose.yml
+          grep -R "guarded" docs infra docker-compose.yml

--- a/.vercelignore
+++ b/.vercelignore
@@ -42,9 +42,9 @@ lerna-debug.log*
 *.sw?
 
 # Infrastructure and deployment
-infrastructure/
-deployment/
-terraform/
+/infrastructure/
+/deployment/
+/terraform/
 *.tfstate
 *.tfstate.*
 .terraform/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,127 +1,107 @@
-version: '3.9'
+name: devonn-staging
 
-# Devonn.AI — Local Development Stack
+# Root staging foundation.
 #
-# Services:
-#   frontend  — Vite dev server (hot reload)
-#   backend   — FastAPI Python API
-#   db        — PostgreSQL (mirrors Supabase schema locally)
-#   redis     — Cache / session store
-#   mailhog   — Local SMTP for email testing
+# This file defines the target runtime topology. The app services use
+# ./services/* build contexts, which should be populated by the extraction PR.
+# Until then, run only the infra profile:
 #
-# Usage:
-#   docker compose up              # start all services
-#   docker compose up frontend     # start frontend only
-#   docker compose logs -f backend # tail backend logs
-#   docker compose down -v         # stop and remove volumes
+#   docker compose up postgres redis qdrant
+#
+# After services are extracted:
+#
+#   docker compose --profile app up --build
 
 services:
-
-  # ── Frontend (Vite + React) ─────────────────────────────────────────────────
-  frontend:
-    build:
-      context: .
-      dockerfile: Dockerfile.frontend
-      target: builder          # use the builder stage for hot reload
-    ports:
-      - "5173:5173"
-    volumes:
-      - .:/app
-      - /app/node_modules      # prevent host node_modules from overriding
-    environment:
-      - NODE_ENV=development
-      - VITE_API_URL=http://localhost:8000
-      - VITE_SUPABASE_URL=${VITE_SUPABASE_URL}
-      - VITE_SUPABASE_ANON_KEY=${VITE_SUPABASE_ANON_KEY}
-    command: npm run dev -- --host 0.0.0.0
-    depends_on:
-      - backend
-    networks:
-      - devonn-net
-
-  # ── Backend (FastAPI Python) ────────────────────────────────────────────────
-  backend:
-    build:
-      context: ./backend
-      dockerfile: Dockerfile
-    ports:
-      - "8000:8000"
-    volumes:
-      - ./backend:/app         # hot reload via uvicorn --reload
-    environment:
-      - ENVIRONMENT=development
-      - DATABASE_URL=postgresql://devonn:devonn_secret@db:5432/devonn_dev
-      - REDIS_URL=redis://redis:6379/0
-      - OPENAI_API_KEY=${OPENAI_API_KEY}
-      - JWT_SECRET=${JWT_SECRET:-dev_jwt_secret_change_in_production}
-    command: uvicorn main:app --host 0.0.0.0 --port 8000 --reload
-    depends_on:
-      db:
-        condition: service_healthy
-      redis:
-        condition: service_healthy
-    networks:
-      - devonn-net
-    healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8000/health"]
-      interval: 30s
-      timeout: 10s
-      retries: 3
-      start_period: 15s
-
-  # ── PostgreSQL Database ─────────────────────────────────────────────────────
-  db:
+  postgres:
     image: postgres:16-alpine
+    env_file:
+      - .env.staging.local
     ports:
       - "5432:5432"
-    environment:
-      POSTGRES_USER: devonn
-      POSTGRES_PASSWORD: devonn_secret
-      POSTGRES_DB: devonn_dev
     volumes:
-      - postgres_data:/var/lib/postgresql/data
-      # Auto-run migrations on first start
-      - ./supabase/migrations:/docker-entrypoint-initdb.d:ro
-    networks:
-      - devonn-net
+      - postgres-data:/var/lib/postgresql/data
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U devonn -d devonn_dev"]
+      test: ["CMD-SHELL", "pg_isready -U $$POSTGRES_USER -d $$POSTGRES_DB"]
       interval: 10s
       timeout: 5s
-      retries: 5
-      start_period: 10s
+      retries: 10
 
-  # ── Redis Cache ─────────────────────────────────────────────────────────────
   redis:
     image: redis:7-alpine
+    command: ["redis-server", "--appendonly", "yes"]
     ports:
       - "6379:6379"
     volumes:
-      - redis_data:/data
-    command: redis-server --appendonly yes --maxmemory 256mb --maxmemory-policy allkeys-lru
-    networks:
-      - devonn-net
+      - redis-data:/data
     healthcheck:
       test: ["CMD", "redis-cli", "ping"]
       interval: 10s
       timeout: 5s
-      retries: 3
+      retries: 10
 
-  # ── MailHog (local email testing) ───────────────────────────────────────────
-  mailhog:
-    image: mailhog/mailhog:latest
+  qdrant:
+    image: qdrant/qdrant:v1.12.4
     ports:
-      - "1025:1025"   # SMTP
-      - "8025:8025"   # Web UI — open http://localhost:8025 to view emails
-    networks:
-      - devonn-net
+      - "6333:6333"
+      - "6334:6334"
+    volumes:
+      - qdrant-data:/qdrant/storage
+
+  api:
+    build:
+      context: ./services/api
+    profiles: ["app"]
+    env_file:
+      - .env.staging.local
+    ports:
+      - "8000:8000"
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+      qdrant:
+        condition: service_started
+
+  orchestrator:
+    build:
+      context: ./services/orchestrator
+    profiles: ["app"]
+    env_file:
+      - .env.staging.local
+    ports:
+      - "7373:7373"
+      - "7374:7374"
+    depends_on:
+      redis:
+        condition: service_healthy
+
+  worker:
+    build:
+      context: ./services/workers
+    profiles: ["app"]
+    env_file:
+      - .env.staging.local
+    depends_on:
+      redis:
+        condition: service_healthy
+      api:
+        condition: service_started
+
+  frontend:
+    build:
+      context: ./services/frontend
+    profiles: ["app"]
+    env_file:
+      - .env.staging.local
+    ports:
+      - "5173:5173"
+    depends_on:
+      api:
+        condition: service_started
 
 volumes:
-  postgres_data:
-    driver: local
-  redis_data:
-    driver: local
-
-networks:
-  devonn-net:
-    driver: bridge
+  postgres-data:
+  redis-data:
+  qdrant-data:

--- a/docs/ENVIRONMENT_VARIABLES.md
+++ b/docs/ENVIRONMENT_VARIABLES.md
@@ -1,0 +1,85 @@
+# Devonn.ai Staging Environment Contract
+
+Do not commit local environment files or real credentials. Local-only values belong in `.env.staging.local`, which must remain untracked.
+
+## Required staging defaults
+
+```text
+ENVIRONMENT=staging
+AUTONOMY_MODE=guarded
+EXECUTION_MODE=dry-run
+```
+
+These values are mandatory for staging because they prevent the system from behaving like production before the deployment shape is proven.
+
+## Core runtime groups
+
+### Runtime identity
+
+Used by all services.
+
+- environment name
+- autonomy mode
+- execution mode
+- log level
+
+### Database
+
+Used by API and local compose database.
+
+- local database name
+- local database user
+- local database password
+- application database connection URL
+
+Managed staging connection values must be stored only in the hosting provider's secret manager.
+
+### Queue and cache
+
+Used by API, orchestrator, and worker.
+
+- Redis-compatible connection URL
+- queue name
+- queue namespace
+
+### Vector memory
+
+Used by API and retrieval components.
+
+- vector database URL
+- vector database access token, when required by the provider
+- collection/index name
+
+### Service URLs
+
+Used by frontend, orchestrator, and worker.
+
+- internal API base URL
+- browser-visible API base URL
+- orchestrator URL, if exposed
+
+### Auth and frontend integration
+
+Used only when auth is active.
+
+- public frontend auth URL
+- public frontend auth client key
+- server-side service credential, API only
+
+### AI providers
+
+Used by API and worker only.
+
+- provider credentials must be platform secrets
+- never expose provider credentials to frontend code
+- never commit provider credentials to git
+
+## Local file rule
+
+`.env.staging.local` is intentionally referenced by compose but must not be committed.
+
+The staging CI workflow blocks this exact filename if it is tracked.
+
+## Promotion rule
+
+Before production promotion, confirm that staging values are not reused for production and production values are not present in local files.

--- a/docs/GUARDRAILS.md
+++ b/docs/GUARDRAILS.md
@@ -1,0 +1,87 @@
+# Devonn.ai Staging Guardrails
+
+## Purpose
+
+Staging proves build, deploy, health, readiness, queue, and observability behavior before any production rollout.
+
+## Mandatory staging posture
+
+```text
+ENVIRONMENT=staging
+AUTONOMY_MODE=guarded
+EXECUTION_MODE=dry-run
+```
+
+## Default rule
+
+Staging may plan and simulate work. Staging must not directly change production systems.
+
+## Not allowed in staging by default
+
+- direct production data changes
+- direct production infrastructure changes
+- direct production traffic changes
+- direct pushes to the protected default branch
+- irreversible external actions
+- unattended release promotion
+
+## Allowed in staging by default
+
+- health checks
+- readiness checks
+- local compose validation
+- preview deployments
+- dry-run workflow planning
+- synthetic queue messages
+- staging-only data tests
+- logs and telemetry collection
+- human-reviewed pull requests
+
+## Human approval gate
+
+Any production-impacting action needs a separate approval path and rollback note.
+
+Minimum approval record:
+
+- requested action
+- target environment
+- rollback note
+- approving human
+- timestamp
+
+## CI expectations
+
+The staging CI gate verifies:
+
+- required staging files exist
+- compose syntax is valid
+- local environment files are not committed
+- guarded and dry-run defaults are present
+
+## Runtime expectations
+
+Services should emit structured logs when staging blocks a risky action.
+
+Example shape:
+
+```json
+{
+  "event": "staging_action_blocked",
+  "environment": "staging",
+  "mode": "guarded",
+  "execution_mode": "dry-run",
+  "reason": "production-impacting action is not allowed in staging"
+}
+```
+
+## Promotion criteria
+
+Staging is ready for production planning only when:
+
+1. staging CI passes,
+2. service health checks pass,
+3. readiness checks pass where applicable,
+4. no local environment file is committed,
+5. risky actions are blocked and logged,
+6. rollback steps are documented,
+7. production deployment uses a separate runbook.

--- a/docs/STAGING_DEPLOYMENT_RUNBOOK.md
+++ b/docs/STAGING_DEPLOYMENT_RUNBOOK.md
@@ -1,0 +1,124 @@
+# Devonn.ai Staging Deployment Runbook
+
+## Purpose
+
+Create a safe, production-grade staging layer before promoting Devonn.ai workloads into AWS/EKS or production traffic.
+
+## Deployment principle
+
+Staging validates runtime shape, health checks, environment boundaries, and observability before real production execution is allowed.
+
+## Service topology
+
+```text
+Vercel frontend
+  -> Render API
+  -> Render orchestrator
+  -> Render worker
+  -> managed Postgres
+  -> managed Redis
+  -> Qdrant/vector memory
+```
+
+Local validation uses root `docker-compose.yml`.
+
+## Phase 1: local infra validation
+
+Create local env file from the documented contract:
+
+```bash
+cp docs/ENVIRONMENT_VARIABLES.md /tmp/devonn-env-reference.md
+cp .env.example .env.staging.local 2>/dev/null || touch .env.staging.local
+```
+
+Add only local, non-production values to `.env.staging.local`.
+
+Run infra services:
+
+```bash
+docker compose up postgres redis qdrant
+```
+
+Check:
+
+```bash
+docker compose ps
+```
+
+## Phase 2: app service extraction
+
+Populate these folders in a follow-up PR:
+
+```text
+services/frontend
+services/api
+services/orchestrator
+services/workers
+```
+
+Recommended extraction order:
+
+1. `services/frontend` from the current Vite/React frontend.
+2. `services/api` from the healthiest FastAPI API source.
+3. `services/orchestrator` from MyClaw scheduler/control-plane source.
+4. `services/workers` from queue consumer/runtime worker source.
+
+## Phase 3: full local app validation
+
+After service folders are populated:
+
+```bash
+docker compose --profile app up --build
+```
+
+Required checks:
+
+```bash
+curl -f http://localhost:8000/health
+curl -f http://localhost:7373/health
+curl -f http://localhost:7373/ready
+curl -f http://localhost:5173
+```
+
+## Phase 4: managed staging deploy
+
+Use:
+
+- Vercel for frontend staging.
+- Render blueprint at `infra/render/render.yaml` for API, orchestrator, and worker.
+- Managed Postgres, Redis, and Qdrant/compatible vector service.
+
+Required guardrail values:
+
+```text
+ENVIRONMENT=staging
+AUTONOMY_MODE=guarded
+EXECUTION_MODE=dry-run
+```
+
+## Phase 5: promotion criteria
+
+Do not promote staging until all are true:
+
+- GitHub Actions `Staging CI` passes.
+- API `/health` passes.
+- Orchestrator `/health` passes.
+- Orchestrator `/ready` passes.
+- Worker starts without crashing.
+- No secrets committed.
+- Logs show blocked/guarded actions when risky actions are requested.
+- Frontend can reach staging API.
+- No production memory mutation is enabled.
+
+## Rollback
+
+If staging breaks:
+
+1. Disable Render auto-deploy.
+2. Revert the latest staging PR.
+3. Restore previous Vercel preview deployment.
+4. Keep production traffic unchanged.
+
+## Next implementation PR
+
+After this foundation lands, the next PR should add real service wrappers and Dockerfiles under `services/*` while keeping the original project folders intact until tests are green.

--- a/docs/STAGING_SERVICE_MAP.md
+++ b/docs/STAGING_SERVICE_MAP.md
@@ -1,0 +1,64 @@
+# Devonn.ai Staging Service Map
+
+This document normalizes the existing fragmented workspace into a clean staging deployment shape without deleting or rewriting the original project folders.
+
+## Target root layout
+
+```text
+services/
+  frontend/
+  api/
+  orchestrator/
+  workers/
+infra/
+  render/
+  vercel/
+observability/
+  local/
+docs/
+  STAGING_DEPLOYMENT_RUNBOOK.md
+  ENVIRONMENT_VARIABLES.md
+  GUARDRAILS.md
+```
+
+## Existing folder to staged service mapping
+
+| Staged service | Primary source | Secondary source | Reason |
+| --- | --- | --- | --- |
+| `services/frontend` | `supreme-ai-deployment-hub` root frontend | `devonn-ai` frontend assets if still active | Vite/React frontend and existing `vercel.json` live here. |
+| `services/api` | `hermes-ai` | `devonn-gitnexus-bridge` | FastAPI-style API/service endpoints already expose `/health`. |
+| `services/orchestrator` | `MyClaw` | `hermes-ai` runtime coordination modules | MyClaw owns scheduler/control-plane behavior and already has `/health` and `/ready`. |
+| `services/workers` | `MyClaw` runtime workers | future queue consumers | Worker runtime should consume Redis-backed jobs and call API/orchestrator boundaries. |
+| `observability/local` | new root foundation | existing scattered metrics/log scripts | Local-only staging visibility for compose validation. |
+| `infra/render` | new root foundation | existing Dockerfiles | Render staging blueprint for API/orchestrator/worker managed services. |
+| `infra/vercel` | existing `vercel.json` | new staging notes | Frontend deployment remains Vercel-first. |
+
+## Normalization rule
+
+Do not move production code until the staging contract is green. Use this phase to add a root-level runtime wrapper and documentation first. Once compose, staging CI, and health checks are stable, code can be copied or extracted into `services/*` in a follow-up PR.
+
+## Staging contract
+
+Every staged service must provide:
+
+- deterministic build command
+- deterministic start command
+- `/health` endpoint where applicable
+- `/ready` endpoint for orchestrator-style services where applicable
+- environment variables documented in `docs/ENVIRONMENT_VARIABLES.md`
+- no secrets committed to git
+- no autonomous irreversible actions enabled by default
+
+## Current status
+
+This branch intentionally adds the deployment foundation first:
+
+- root `docker-compose.yml`
+- Render blueprint stub
+- Vercel staging notes
+- staging CI workflow
+- staging runbook
+- environment variable contract
+- guardrails contract
+
+The next PR should extract real service entrypoints under `services/*` or convert these wrappers into direct build contexts once the exact runtime source is confirmed.

--- a/infra/render/render.yaml
+++ b/infra/render/render.yaml
@@ -48,6 +48,8 @@ services:
     envVars:
       - key: ENVIRONMENT
         value: staging
+      - key: AUTONOMY_MODE
+        value: guarded
       - key: EXECUTION_MODE
         value: dry-run
       - key: API_BASE_URL

--- a/infra/render/render.yaml
+++ b/infra/render/render.yaml
@@ -1,0 +1,56 @@
+services:
+  - type: web
+    name: devonn-api-staging
+    env: docker
+    plan: starter
+    rootDir: services/api
+    healthCheckPath: /health
+    autoDeploy: false
+    envVars:
+      - key: ENVIRONMENT
+        value: staging
+      - key: AUTONOMY_MODE
+        value: guarded
+      - key: EXECUTION_MODE
+        value: dry-run
+      - key: DATABASE_URL
+        sync: false
+      - key: REDIS_URL
+        sync: false
+      - key: QDRANT_URL
+        sync: false
+
+  - type: web
+    name: devonn-orchestrator-staging
+    env: docker
+    plan: starter
+    rootDir: services/orchestrator
+    healthCheckPath: /health
+    autoDeploy: false
+    envVars:
+      - key: ENVIRONMENT
+        value: staging
+      - key: AUTONOMY_MODE
+        value: guarded
+      - key: EXECUTION_MODE
+        value: dry-run
+      - key: API_BASE_URL
+        sync: false
+      - key: REDIS_URL
+        sync: false
+
+  - type: worker
+    name: devonn-worker-staging
+    env: docker
+    plan: starter
+    rootDir: services/workers
+    autoDeploy: false
+    envVars:
+      - key: ENVIRONMENT
+        value: staging
+      - key: EXECUTION_MODE
+        value: dry-run
+      - key: API_BASE_URL
+        sync: false
+      - key: REDIS_URL
+        sync: false

--- a/infra/vercel/staging.md
+++ b/infra/vercel/staging.md
@@ -1,0 +1,34 @@
+# Vercel Staging Notes
+
+Frontend staging remains Vercel-first.
+
+## Expected project shape
+
+- Frontend source: `services/frontend`
+- Build command: `npm run build`
+- Output directory: `dist`
+- Framework preset: Vite
+
+## Required environment variables
+
+- `VITE_API_BASE_URL`
+- `VITE_ORCHESTRATOR_URL`
+- `VITE_SUPABASE_URL` if Supabase is active
+- `VITE_SUPABASE_PUBLISHABLE_KEY` if Supabase is active
+
+## Deployment rule
+
+Do not point production `devonn.ai` traffic at this staging branch until:
+
+1. `staging-ci.yml` passes.
+2. API `/health` passes.
+3. Orchestrator `/health` and `/ready` pass.
+4. Guardrails remain in `dry-run` / `guarded` mode.
+5. No secrets are committed.
+
+## Follow-up extraction
+
+The current root repository has existing Vercel configuration. This staging layer documents the target. The next PR should either:
+
+1. copy the current frontend into `services/frontend`, or
+2. update Vercel root directory settings to match the existing frontend location while retaining this staging contract.

--- a/observability/local/README.md
+++ b/observability/local/README.md
@@ -1,0 +1,35 @@
+# Local Observability Foundation
+
+This folder is reserved for the local staging observability stack.
+
+## Target components
+
+- Prometheus for metrics scraping
+- Grafana for dashboards
+- Loki for log aggregation
+- OpenTelemetry Collector for trace/metric forwarding
+
+## Minimum staging signals
+
+Every staged service should eventually emit:
+
+- health status
+- readiness status where applicable
+- request count
+- request latency
+- error count
+- queue depth for worker/orchestrator paths
+- guarded-action count
+- blocked-action count
+
+## Activation plan
+
+This branch keeps observability as a documented foundation only. The next implementation PR should add:
+
+```text
+observability/local/prometheus.yml
+observability/local/grafana/provisioning/datasources/prometheus.yml
+observability/local/grafana/provisioning/dashboards/devonn-staging.yml
+observability/local/loki-config.yml
+observability/local/otel-collector.yml
+```


### PR DESCRIPTION
## Summary

Adds the root staging deployment foundation requested by the workspace audit.

## What changed

- Added `docs/STAGING_SERVICE_MAP.md` to map existing fragmented folders into the target staged service layout.
- Normalized root `docker-compose.yml` into the intended staging topology: frontend, API, orchestrator, worker, Postgres, Redis, and Qdrant.
- Added `infra/render/render.yaml` for managed staging service targets.
- Added `infra/vercel/staging.md` for Vercel frontend staging rules.
- Added `.github/workflows/staging-ci.yml` to validate the staging foundation.
- Added `observability/local/README.md` for the local observability activation plan.
- Added staging runbook, environment contract, and guardrails docs.

## Important note

This PR does not extract live code into `services/*` yet. It intentionally lands the deployment contract first so the next PR can move or wrap the real service entrypoints cleanly.

## Next PR

Populate:

- `services/frontend`
- `services/api`
- `services/orchestrator`
- `services/workers`

Then run full compose validation with:

```bash
docker compose --profile app up --build
```

## Safety

Staging defaults remain guarded and dry-run. No real environment values are committed.