### PR TITLE
Extract staging frontend and API service adapters

### DIFF
--- a/.github/workflows/staging-ci.yml
+++ b/.github/workflows/staging-ci.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - main
+      - staging/foundation-runtime
     paths:
       - "docker-compose.yml"
       - "services/**"
@@ -61,6 +62,21 @@ jobs:
         shell: bash
         run: docker compose -f docker-compose.yml config >/tmp/devonn-compose.yml
 
+      - name: Validate frontend and API Dockerfiles exist
+        shell: bash
+        run: |
+          set -euo pipefail
+          test -f services/frontend/Dockerfile
+          test -f services/frontend/MIGRATION.md
+          test -f services/api/Dockerfile
+          test -f services/api/MIGRATION.md
+
+      - name: Build Cut 1 service images
+        shell: bash
+        run: |
+          set -euo pipefail
+          docker compose --profile app build api frontend
+
       - name: Validate no committed staging env file
         shell: bash
         run: |
@@ -74,5 +90,5 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          grep -R "dry-run" docs infra docker-compose.yml
-          grep -R "guarded" docs infra docker-compose.yml
+          grep -R "dry-run" docs infra docker-compose.yml services
+          grep -R "guarded" docs infra docker-compose.yml services

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,15 +2,15 @@ name: devonn-staging
 
 # Root staging foundation.
 #
-# This file defines the target runtime topology. The app services use
-# ./services/* build contexts, which should be populated by the extraction PR.
-# Until then, run only the infra profile:
+# Cut 1 wires frontend and API as service adapters while preserving the
+# current repo layout. The Docker build context stays at repo root and each
+# service uses its own Dockerfile under services/*.
 #
-#   docker compose up postgres redis qdrant
+# Core app validation:
 #
-# After services are extracted:
-#
-#   docker compose --profile app up --build
+#   docker compose --profile app up --build frontend api postgres redis qdrant
+#   curl -f http://localhost:8000/health
+#   curl -f http://localhost:8000/ready
 
 services:
   postgres:
@@ -50,10 +50,15 @@ services:
 
   api:
     build:
-      context: ./services/api
+      context: .
+      dockerfile: services/api/Dockerfile
     profiles: ["app"]
     env_file:
       - .env.staging.local
+    environment:
+      ENVIRONMENT: staging
+      AUTONOMY_MODE: guarded
+      EXECUTION_MODE: dry-run
     ports:
       - "8000:8000"
     depends_on:
@@ -91,10 +96,14 @@ services:
 
   frontend:
     build:
-      context: ./services/frontend
+      context: .
+      dockerfile: services/frontend/Dockerfile
     profiles: ["app"]
     env_file:
       - .env.staging.local
+    environment:
+      VITE_API_BASE_URL: ${VITE_API_BASE_URL:-http://localhost:8000}
+      VITE_ORCHESTRATOR_URL: ${VITE_ORCHESTRATOR_URL:-http://localhost:7373}
     ports:
       - "5173:5173"
     depends_on:

--- a/services/api/Dockerfile
+++ b/services/api/Dockerfile
@@ -1,0 +1,30 @@
+# Devonn.ai staging API adapter
+#
+# Build context: repo root
+# Runtime source: existing backend/ FastAPI application
+
+FROM python:3.11-slim AS runtime
+
+ENV PYTHONDONTWRITEBYTECODE=1
+ENV PYTHONUNBUFFERED=1
+ENV ENVIRONMENT=staging
+ENV AUTONOMY_MODE=guarded
+ENV EXECUTION_MODE=dry-run
+
+WORKDIR /app
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends curl \
+  && rm -rf /var/lib/apt/lists/*
+
+COPY backend/requirements.txt ./backend/requirements.txt
+RUN pip install --no-cache-dir -r backend/requirements.txt
+
+COPY backend ./backend
+
+EXPOSE 8000
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+  CMD curl -fsS http://localhost:8000/health >/dev/null || exit 1
+
+CMD ["uvicorn", "backend.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/services/api/MIGRATION.md
+++ b/services/api/MIGRATION.md
@@ -1,0 +1,64 @@
+# API Service Migration
+
+## Target service
+
+`services/api`
+
+## Source of truth
+
+Existing FastAPI backend:
+
+- `backend/main.py`
+- `backend/api/`
+- `backend/agents/`
+- `backend/middleware/`
+- `backend/db/`
+- `backend/requirements.txt`
+- `Dockerfile.hardened` for hardened production image reference
+
+## Current cut
+
+Cut 1 does not physically move the backend package. It adds a service-specific Docker adapter at `services/api/Dockerfile` while keeping the Docker build context at repo root.
+
+This proves the API staged service boundary without destabilizing imports that currently expect `backend.*`.
+
+## Entrypoint
+
+```bash
+uvicorn backend.main:app --host 0.0.0.0 --port 8000
+```
+
+## Health contract
+
+Required endpoints:
+
+```bash
+curl -f http://localhost:8000/health
+curl -f http://localhost:8000/ready
+```
+
+## Environment contract
+
+Required staging posture:
+
+```text
+ENVIRONMENT=staging
+AUTONOMY_MODE=guarded
+EXECUTION_MODE=dry-run
+```
+
+Service connections:
+
+- application database connection URL
+- Redis-compatible connection URL
+- vector database URL
+- allowed frontend origins
+
+Provider credentials must remain platform-managed and must not be committed.
+
+## Deferred
+
+- physically moving `backend/` into `services/api/backend/`
+- distroless hardened runtime conversion
+- API-to-database migration checks
+- API smoke test workflow that boots the container and curls `/health` + `/ready`

--- a/services/frontend/Dockerfile
+++ b/services/frontend/Dockerfile
@@ -1,0 +1,34 @@
+# Devonn.ai staging frontend adapter
+#
+# Build context: repo root
+# Runtime source: existing root Vite/React application
+
+FROM node:22-alpine AS builder
+
+WORKDIR /app
+
+COPY package.json package-lock.json ./
+RUN npm ci
+
+COPY . .
+
+RUN npm run typecheck
+RUN npm run build
+
+FROM node:22-alpine AS runtime
+
+WORKDIR /app
+
+RUN npm install -g serve@14.2.4
+
+COPY --from=builder /app/dist ./dist
+
+ENV HOST=0.0.0.0
+ENV PORT=5173
+
+EXPOSE 5173
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+  CMD wget -qO- http://localhost:5173 >/dev/null 2>&1 || exit 1
+
+CMD ["serve", "-s", "dist", "-l", "5173"]

--- a/services/frontend/MIGRATION.md
+++ b/services/frontend/MIGRATION.md
@@ -1,0 +1,62 @@
+# Frontend Service Migration
+
+## Target service
+
+`services/frontend`
+
+## Source of truth
+
+Current root Vite/React application:
+
+- `package.json`
+- `package-lock.json`
+- `src/`
+- `public/`
+- `index.html`
+- `vite.config.*`
+- `tailwind.config.*`
+- `postcss.config.*`
+- `nginx.conf` for hardened production serving reference
+- `Dockerfile.frontend` for hardened production image reference
+
+## Current cut
+
+Cut 1 does not physically move the frontend source tree. It adds a service-specific Docker adapter at `services/frontend/Dockerfile` while keeping the Docker build context at repo root.
+
+This avoids a high-risk source move while proving the staged service boundary.
+
+## Entrypoint
+
+Build:
+
+```bash
+npm ci
+npm run typecheck
+npm run build
+```
+
+Run:
+
+```bash
+serve -s dist -l 5173
+```
+
+## Health contract
+
+The container healthcheck verifies the static frontend responds on port `5173`.
+
+## Environment contract
+
+Browser-visible values only:
+
+- `VITE_API_BASE_URL`
+- `VITE_ORCHESTRATOR_URL`
+
+Do not expose server-only credentials in frontend environment variables.
+
+## Deferred
+
+- physically moving root frontend files into `services/frontend`
+- updating Vercel root directory
+- replacing the adapter with the hardened Nginx production image
+- frontend-to-API smoke test automation


### PR DESCRIPTION
## Summary

PR #2 Cut 1: wires the first two staged services without moving the full app tree yet.

This is intentionally stacked on top of PR #168 / `staging/foundation-runtime`.

## What changed

- Updated root `docker-compose.yml` so `frontend` and `api` build from repo root using service-specific Dockerfiles.
- Added `services/frontend/Dockerfile` as a staging adapter for the existing root Vite/React app.
- Added `services/frontend/MIGRATION.md` with source paths, entrypoint, env contract, health contract, and deferred work.
- Added `services/api/Dockerfile` as a staging adapter for the existing `backend/` FastAPI app.
- Added `services/api/MIGRATION.md` with source paths, entrypoint, env contract, health contract, and deferred work.
- Extended Staging CI to validate the adapter files and build only the Cut 1 images: `api` and `frontend`.

## Validation target

```bash
docker compose --profile app up --build frontend api postgres redis qdrant
curl -f http://localhost:8000/health
curl -f http://localhost:8000/ready
```

## Deferred to Cut 2

- `services/orchestrator`
- `services/workers`
- queue runtime semantics
- MyClaw/Hermes orchestration extraction

## Safety

- Keeps staging defaults: `ENVIRONMENT=staging`, `AUTONOMY_MODE=guarded`, `EXECUTION_MODE=dry-run`.
- Does not commit local env files.
- Does not move production source paths yet, reducing import breakage risk.