### PR TITLE
Add Devonn Speech Intelligence module integration

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -23,6 +23,15 @@ class Settings(BaseSettings):
     elevenlabs_default_model: str = "eleven_turbo_v2_5"
     assemblyai_api_key: str = ""
 
+    # ── Speech Intelligence ────────────────────────────────────────────────────
+    # External Whisper/Distil-Whisper microservice. Keep this service separately
+    # scalable because model loading and GPU/CPU requirements differ from the
+    # normal Devonn backend proxy.
+    speech_intelligence_base_url: str = ""
+    speech_intelligence_api_key: str = ""
+    speech_intelligence_timeout_seconds: int = 900
+    speech_intelligence_max_upload_mb: int = 250
+
     # ── CI/CD ──────────────────────────────────────────────────────────────────
     github_token: str = ""
     github_repo: str = "wesship/supreme-ai-deployment-hub"

--- a/backend/app/models/speech.py
+++ b/backend/app/models/speech.py
@@ -1,0 +1,56 @@
+"""
+Devonn.ai Speech Intelligence models.
+
+These schemas describe the backend proxy response returned by the external
+Speech Intelligence microservice. The microservice performs Whisper/Distil-
+Whisper transcription and lightweight transcript intelligence; this backend
+keeps provider keys and service URLs server-side.
+"""
+from typing import Any, Optional
+
+from pydantic import BaseModel, Field
+
+
+class SpeechChunk(BaseModel):
+    start: float = Field(..., ge=0)
+    end: float = Field(..., ge=0)
+    text: str = Field(..., min_length=1)
+
+
+class SpeechGraphNode(BaseModel):
+    id: str
+    label: str
+    type: str = "concept"
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+
+class SpeechGraphEdge(BaseModel):
+    source: str
+    target: str
+    relationship: str = "related_to"
+    weight: float = Field(default=1.0, ge=0)
+
+
+class SpeechKnowledgeGraph(BaseModel):
+    nodes: list[SpeechGraphNode] = Field(default_factory=list)
+    edges: list[SpeechGraphEdge] = Field(default_factory=list)
+
+
+class SpeechTranscriptionResponse(BaseModel):
+    status: str = "completed"
+    job_id: Optional[str] = None
+    filename: str
+    model: str
+    transcript: str
+    chunks: list[SpeechChunk] = Field(default_factory=list)
+    summary: Optional[str] = None
+    topics: list[str] = Field(default_factory=list)
+    action_items: list[str] = Field(default_factory=list)
+    knowledge_graph: Optional[SpeechKnowledgeGraph] = None
+    raw: dict[str, Any] = Field(default_factory=dict)
+
+
+class SpeechHealthResponse(BaseModel):
+    configured: bool
+    service_url: str
+    status: str

--- a/backend/app/routers/__init__.py
+++ b/backend/app/routers/__init__.py
@@ -8,6 +8,7 @@ from backend.app.routers.chat import router as chat_router
 from backend.app.routers.rag import router as rag_router
 from backend.app.routers.tools import router as tools_router
 from backend.app.routers.admin import router as admin_router
+from backend.app.routers.speech import router as speech_router
 
 proxy_router = APIRouter(prefix="/api")
 
@@ -15,3 +16,4 @@ proxy_router.include_router(chat_router, tags=["chat"])
 proxy_router.include_router(rag_router, tags=["rag"])
 proxy_router.include_router(tools_router, tags=["tools"])
 proxy_router.include_router(admin_router, tags=["admin"])
+proxy_router.include_router(speech_router, tags=["speech"])

--- a/backend/app/routers/speech.py
+++ b/backend/app/routers/speech.py
@@ -1,0 +1,174 @@
+"""
+Devonn.ai Backend Proxy — /api/speech
+
+Secure proxy routes for the Speech Intelligence microservice. The frontend sends
+media files to this backend, and this backend forwards them to the separately
+scalable Whisper service. Service URLs and API keys remain server-side only.
+"""
+import logging
+from typing import Optional
+
+import httpx
+from fastapi import APIRouter, Depends, File, Form, HTTPException, UploadFile, status
+
+from backend.app.config import get_settings
+from backend.app.middleware.auth import get_current_user_id
+from backend.app.middleware.rate_limit import rate_limit
+from backend.app.models.speech import SpeechHealthResponse, SpeechTranscriptionResponse
+
+logger = logging.getLogger(__name__)
+router = APIRouter()
+
+_ALLOWED_MEDIA_TYPES = {
+    "audio/mpeg",
+    "audio/mp3",
+    "audio/wav",
+    "audio/x-wav",
+    "audio/mp4",
+    "audio/m4a",
+    "audio/webm",
+    "video/mp4",
+    "video/webm",
+    "video/quicktime",
+    "application/octet-stream",
+}
+
+
+@router.get(
+    "/speech/health",
+    response_model=SpeechHealthResponse,
+    summary="Speech Intelligence health",
+    description="Check whether the Speech Intelligence service is configured behind the Devonn backend.",
+)
+async def speech_health(
+    user_id: str = Depends(get_current_user_id),
+    _rate: None = Depends(rate_limit(30)),
+) -> SpeechHealthResponse:
+    settings = get_settings()
+    base_url = settings.speech_intelligence_base_url.rstrip("/")
+    if not base_url:
+        return SpeechHealthResponse(configured=False, service_url="", status="missing SPEECH_INTELLIGENCE_BASE_URL")
+
+    headers = _speech_headers(settings.speech_intelligence_api_key)
+    try:
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            resp = await client.get(f"{base_url}/health", headers=headers)
+    except httpx.HTTPError as exc:
+        logger.warning("speech_health user=%s error=%s", user_id, exc)
+        return SpeechHealthResponse(configured=True, service_url=base_url, status=f"unreachable: {exc}")
+
+    if resp.status_code >= 400:
+        return SpeechHealthResponse(configured=True, service_url=base_url, status=f"error {resp.status_code}")
+    return SpeechHealthResponse(configured=True, service_url=base_url, status="ok")
+
+
+@router.post(
+    "/speech/transcribe",
+    response_model=SpeechTranscriptionResponse,
+    summary="Transcribe audio/video",
+    description="Upload audio or video and receive transcript chunks, summary, topics, action items, and concept graph output.",
+)
+async def transcribe_media(
+    file: UploadFile = File(...),
+    model: str = Form(default="openai/whisper-large-v3"),
+    language: Optional[str] = Form(default=None),
+    task: str = Form(default="transcribe"),
+    include_graph: bool = Form(default=True),
+    save_to_crm: bool = Form(default=False),
+    crm_contact_id: Optional[str] = Form(default=None),
+    user_id: str = Depends(get_current_user_id),
+    _rate: None = Depends(rate_limit(10)),
+) -> SpeechTranscriptionResponse:
+    settings = get_settings()
+    base_url = settings.speech_intelligence_base_url.rstrip("/")
+    if not base_url:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Speech Intelligence service not configured (set SPEECH_INTELLIGENCE_BASE_URL on server)",
+        )
+
+    if file.content_type and file.content_type not in _ALLOWED_MEDIA_TYPES:
+        raise HTTPException(
+            status_code=status.HTTP_415_UNSUPPORTED_MEDIA_TYPE,
+            detail=f"Unsupported media type '{file.content_type}'. Upload WAV, MP3, M4A, WebM, MOV, or MP4.",
+        )
+
+    content = await file.read()
+    if not content:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Uploaded file was empty")
+    if len(content) > settings.speech_intelligence_max_upload_mb * 1024 * 1024:
+        raise HTTPException(
+            status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+            detail=f"File exceeds {settings.speech_intelligence_max_upload_mb} MB upload limit",
+        )
+
+    data = {
+        "model": model,
+        "task": task,
+        "include_graph": str(include_graph).lower(),
+        "save_to_crm": str(save_to_crm).lower(),
+        "user_id": user_id,
+    }
+    if language:
+        data["language"] = language
+    if crm_contact_id:
+        data["crm_contact_id"] = crm_contact_id
+
+    headers = _speech_headers(settings.speech_intelligence_api_key)
+    files = {
+        "file": (
+            file.filename or "upload",
+            content,
+            file.content_type or "application/octet-stream",
+        )
+    }
+
+    try:
+        async with httpx.AsyncClient(timeout=settings.speech_intelligence_timeout_seconds) as client:
+            resp = await client.post(
+                f"{base_url}/api/speech/transcribe",
+                data=data,
+                files=files,
+                headers=headers,
+            )
+    except httpx.TimeoutException as exc:
+        logger.exception("speech_transcribe timeout user=%s filename=%s", user_id, file.filename)
+        raise HTTPException(status_code=status.HTTP_504_GATEWAY_TIMEOUT, detail=f"Speech service timed out: {exc}") from exc
+    except httpx.HTTPError as exc:
+        logger.exception("speech_transcribe upstream error user=%s filename=%s", user_id, file.filename)
+        raise HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail=f"Speech service unreachable: {exc}") from exc
+
+    if resp.status_code >= 400:
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail=f"Speech service error {resp.status_code}: {resp.text[:500]}",
+        )
+
+    payload = resp.json()
+    logger.info(
+        "speech_transcribe user=%s filename=%s model=%s bytes=%d",
+        user_id,
+        file.filename,
+        model,
+        len(content),
+    )
+    return SpeechTranscriptionResponse(
+        filename=payload.get("filename") or file.filename or "upload",
+        model=payload.get("model") or model,
+        status=payload.get("status", "completed"),
+        job_id=payload.get("job_id"),
+        transcript=payload.get("transcript", ""),
+        chunks=payload.get("chunks", []),
+        summary=payload.get("summary"),
+        topics=payload.get("topics", []),
+        action_items=payload.get("action_items", []),
+        knowledge_graph=payload.get("knowledge_graph"),
+        raw=payload,
+    )
+
+
+def _speech_headers(api_key: str) -> dict[str, str]:
+    headers: dict[str, str] = {"Accept": "application/json"}
+    if api_key:
+        headers["Authorization"] = f"Bearer {api_key}"
+    return headers

--- a/docs/SPEECH_INTELLIGENCE_IMPLEMENTATION.md
+++ b/docs/SPEECH_INTELLIGENCE_IMPLEMENTATION.md
@@ -1,0 +1,106 @@
+# Devonn.AI Speech Intelligence Implementation
+
+This branch wires the Speech Intelligence Module into the main Devonn.AI repo.
+
+## What was implemented
+
+### Backend
+
+- `backend/app/routers/speech.py`
+  - `GET /api/speech/health`
+  - `POST /api/speech/transcribe`
+- `backend/app/models/speech.py`
+  - Transcript, chunk, topic, action item, and knowledge graph response models.
+- `backend/app/config.py`
+  - `SPEECH_INTELLIGENCE_BASE_URL`
+  - `SPEECH_INTELLIGENCE_API_KEY`
+  - `SPEECH_INTELLIGENCE_TIMEOUT_SECONDS`
+  - `SPEECH_INTELLIGENCE_MAX_UPLOAD_MB`
+- `backend/app/routers/__init__.py`
+  - Registers the speech router under `/api`.
+
+### Frontend
+
+- `src/api/speech/speechApi.ts`
+  - Upload/transcription API client.
+- `src/pages/SpeechIntelligence.tsx`
+  - Admin upload and review panel.
+- `src/App.tsx`
+  - Adds route: `/intelligence/speech`.
+
+## Production environment variables
+
+Set these on the Devonn backend service:
+
+```bash
+SPEECH_INTELLIGENCE_BASE_URL=https://speech-api.devonn.ai
+SPEECH_INTELLIGENCE_API_KEY=<shared-service-token>
+SPEECH_INTELLIGENCE_TIMEOUT_SECONDS=900
+SPEECH_INTELLIGENCE_MAX_UPLOAD_MB=250
+```
+
+The Speech Intelligence microservice should expose:
+
+```http
+GET /health
+POST /api/speech/transcribe
+```
+
+The backend proxy sends a multipart form with:
+
+```text
+file=<audio/video binary>
+model=openai/whisper-large-v3 | distil-whisper/distil-medium.en
+task=transcribe
+language=english
+include_graph=true
+save_to_crm=false
+crm_contact_id=<optional>
+user_id=<authenticated user id>
+```
+
+## Expected response contract
+
+```json
+{
+  "status": "completed",
+  "job_id": "optional-job-id",
+  "filename": "client-call.mp3",
+  "model": "openai/whisper-large-v3",
+  "transcript": "Full transcript text...",
+  "chunks": [
+    { "start": 0.0, "end": 5.12, "text": "Timestamped text..." }
+  ],
+  "summary": "Short summary...",
+  "topics": ["insurance", "follow up"],
+  "action_items": ["Call client tomorrow"],
+  "knowledge_graph": {
+    "nodes": [],
+    "edges": []
+  }
+}
+```
+
+## Deployment flow
+
+1. Deploy the separate Speech Intelligence microservice package.
+2. Add the backend environment variables above.
+3. Deploy this Devonn.AI branch.
+4. Visit `/intelligence/speech`.
+5. Confirm `Service status: ok`.
+6. Upload a short WAV/MP3 first, then test MP4.
+
+## Why it is separated
+
+Whisper Large V3 and Distil-Whisper have different runtime needs than the normal Devonn backend. Keeping this as an external microservice lets Devonn scale GPU/CPU transcription separately from chat, RAG, admin, and agent orchestration.
+
+## Downstream routing
+
+This page prepares the data for:
+
+- CRM call notes
+- Insurance training notes
+- Course transcripts
+- Video summaries
+- Knowledge graph memory
+- Hermes DAG tasks

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -42,6 +42,7 @@ const GitHubConnectorDiagnostic = lazy(() => import("./pages/GitHubConnectorDiag
 const ChatPage = lazy(() => import("./pages/Chat"));
 const AdminPage = lazy(() => import("./pages/Admin"));
 const OperatorCommandCenter = lazy(() => import("./pages/OperatorCommandCenter"));
+const SpeechIntelligence = lazy(() => import("./pages/SpeechIntelligence"));
 const Unauthorized = lazy(() => import("./pages/Unauthorized"));
 
 const PageLoader = () => (
@@ -88,6 +89,7 @@ function App() {
                       <Route path="/privacy-policy" element={<Privacy />} />
                       <Route path="/chat" element={<ChatPage />} />
                       <Route path="/admin" element={<AdminPage />} />
+                      <Route path="/intelligence/speech" element={<SpeechIntelligence />} />
                       <Route
                         path="/occ"
                         element={

--- a/src/api/speech/speechApi.ts
+++ b/src/api/speech/speechApi.ts
@@ -1,0 +1,87 @@
+import { apiClient } from "../core/apiClient";
+
+export interface SpeechChunk {
+  start: number;
+  end: number;
+  text: string;
+}
+
+export interface SpeechGraphNode {
+  id: string;
+  label: string;
+  type: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface SpeechGraphEdge {
+  source: string;
+  target: string;
+  relationship: string;
+  weight: number;
+}
+
+export interface SpeechTranscriptionResponse {
+  status: string;
+  job_id?: string | null;
+  filename: string;
+  model: string;
+  transcript: string;
+  chunks: SpeechChunk[];
+  summary?: string | null;
+  topics: string[];
+  action_items: string[];
+  knowledge_graph?: {
+    nodes: SpeechGraphNode[];
+    edges: SpeechGraphEdge[];
+  } | null;
+  raw?: Record<string, unknown>;
+}
+
+export interface SpeechHealthResponse {
+  configured: boolean;
+  service_url: string;
+  status: string;
+}
+
+export interface TranscribeOptions {
+  model?: string;
+  language?: string;
+  task?: "transcribe" | "translate";
+  includeGraph?: boolean;
+  saveToCrm?: boolean;
+  crmContactId?: string;
+}
+
+export const speechApi = {
+  health: async (): Promise<SpeechHealthResponse> => {
+    const response = await apiClient.get("/api/speech/health");
+    return response.data;
+  },
+
+  transcribe: async (
+    file: File,
+    options: TranscribeOptions = {},
+    onUploadProgress?: (progress: number) => void,
+  ): Promise<SpeechTranscriptionResponse> => {
+    const form = new FormData();
+    form.append("file", file);
+    form.append("model", options.model ?? "openai/whisper-large-v3");
+    form.append("task", options.task ?? "transcribe");
+    form.append("include_graph", String(options.includeGraph ?? true));
+    form.append("save_to_crm", String(options.saveToCrm ?? false));
+
+    if (options.language) form.append("language", options.language);
+    if (options.crmContactId) form.append("crm_contact_id", options.crmContactId);
+
+    const response = await apiClient.post("/api/speech/transcribe", form, {
+      headers: { "Content-Type": "multipart/form-data" },
+      timeout: 15 * 60 * 1000,
+      onUploadProgress: (event) => {
+        if (!onUploadProgress || !event.total) return;
+        onUploadProgress(Math.round((event.loaded / event.total) * 100));
+      },
+    });
+
+    return response.data;
+  },
+};

--- a/src/pages/SpeechIntelligence.tsx
+++ b/src/pages/SpeechIntelligence.tsx
@@ -1,0 +1,224 @@
+import { useEffect, useMemo, useState } from "react";
+import { Upload, FileAudio, Loader2, CheckCircle2, AlertTriangle, Copy } from "lucide-react";
+import { speechApi, SpeechHealthResponse, SpeechTranscriptionResponse } from "../api/speech/speechApi";
+import { Button } from "../components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "../components/ui/card";
+import { Input } from "../components/ui/input";
+import { Label } from "../components/ui/label";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "../components/ui/select";
+import { Switch } from "../components/ui/switch";
+import { Textarea } from "../components/ui/textarea";
+import { toast } from "sonner";
+
+const models = [
+  { value: "openai/whisper-large-v3", label: "Whisper Large V3 — highest accuracy" },
+  { value: "distil-whisper/distil-medium.en", label: "Distil-Whisper Medium EN — faster draft" },
+];
+
+export default function SpeechIntelligence() {
+  const [health, setHealth] = useState<SpeechHealthResponse | null>(null);
+  const [file, setFile] = useState<File | null>(null);
+  const [model, setModel] = useState(models[0].value);
+  const [language, setLanguage] = useState("english");
+  const [includeGraph, setIncludeGraph] = useState(true);
+  const [saveToCrm, setSaveToCrm] = useState(false);
+  const [crmContactId, setCrmContactId] = useState("");
+  const [progress, setProgress] = useState(0);
+  const [loading, setLoading] = useState(false);
+  const [result, setResult] = useState<SpeechTranscriptionResponse | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    speechApi.health()
+      .then(setHealth)
+      .catch((err) => setHealth({ configured: false, service_url: "", status: err?.message ?? "unreachable" }));
+  }, []);
+
+  const canSubmit = useMemo(() => Boolean(file) && !loading, [file, loading]);
+
+  async function handleSubmit() {
+    if (!file) return;
+    setLoading(true);
+    setError(null);
+    setResult(null);
+    setProgress(0);
+
+    try {
+      const response = await speechApi.transcribe(
+        file,
+        {
+          model,
+          language: language.trim() || undefined,
+          includeGraph,
+          saveToCrm,
+          crmContactId: crmContactId.trim() || undefined,
+        },
+        setProgress,
+      );
+      setResult(response);
+      toast.success("Speech intelligence completed");
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Transcription failed";
+      setError(message);
+      toast.error(message);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  function copyTranscript() {
+    if (!result?.transcript) return;
+    navigator.clipboard.writeText(result.transcript);
+    toast.success("Transcript copied");
+  }
+
+  return (
+    <div className="min-h-screen bg-background px-4 py-8 text-foreground md:px-8">
+      <div className="mx-auto flex max-w-6xl flex-col gap-6">
+        <div>
+          <p className="text-sm uppercase tracking-[0.3em] text-muted-foreground">Devonn.AI Intelligence Layer</p>
+          <h1 className="mt-2 text-3xl font-bold md:text-5xl">Speech Intelligence</h1>
+          <p className="mt-3 max-w-3xl text-muted-foreground">
+            Upload audio or video, transcribe it with Whisper, then convert the transcript into summaries,
+            topics, action items, timestamped notes, and concept graph output for CRM, training, and content workflows.
+          </p>
+        </div>
+
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              {health?.status === "ok" ? <CheckCircle2 className="h-5 w-5" /> : <AlertTriangle className="h-5 w-5" />}
+              Service status: {health?.status ?? "checking"}
+            </CardTitle>
+            <CardDescription>
+              Backend proxy target: {health?.service_url || "SPEECH_INTELLIGENCE_BASE_URL not configured"}
+            </CardDescription>
+          </CardHeader>
+        </Card>
+
+        <div className="grid gap-6 lg:grid-cols-[420px_1fr]">
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2"><FileAudio className="h-5 w-5" /> Upload media</CardTitle>
+              <CardDescription>Supported: WAV, MP3, M4A, WebM, MOV, and MP4.</CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-5">
+              <div className="space-y-2">
+                <Label htmlFor="speech-file">Audio or video file</Label>
+                <Input
+                  id="speech-file"
+                  type="file"
+                  accept="audio/*,video/*"
+                  onChange={(event) => setFile(event.target.files?.[0] ?? null)}
+                />
+              </div>
+
+              <div className="space-y-2">
+                <Label>Model</Label>
+                <Select value={model} onValueChange={setModel}>
+                  <SelectTrigger><SelectValue /></SelectTrigger>
+                  <SelectContent>
+                    {models.map((item) => (
+                      <SelectItem key={item.value} value={item.value}>{item.label}</SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+
+              <div className="space-y-2">
+                <Label htmlFor="language">Language hint</Label>
+                <Input id="language" value={language} onChange={(event) => setLanguage(event.target.value)} />
+              </div>
+
+              <div className="flex items-center justify-between rounded-lg border p-3">
+                <div>
+                  <Label>Generate concept graph</Label>
+                  <p className="text-xs text-muted-foreground">Create nodes/edges for Devonn.AI knowledge mapping.</p>
+                </div>
+                <Switch checked={includeGraph} onCheckedChange={setIncludeGraph} />
+              </div>
+
+              <div className="flex items-center justify-between rounded-lg border p-3">
+                <div>
+                  <Label>Prepare CRM note</Label>
+                  <p className="text-xs text-muted-foreground">Send CRM metadata downstream when a contact id is supplied.</p>
+                </div>
+                <Switch checked={saveToCrm} onCheckedChange={setSaveToCrm} />
+              </div>
+
+              {saveToCrm && (
+                <div className="space-y-2">
+                  <Label htmlFor="crm-contact">CRM contact id</Label>
+                  <Input id="crm-contact" value={crmContactId} onChange={(event) => setCrmContactId(event.target.value)} />
+                </div>
+              )}
+
+              <Button className="w-full" disabled={!canSubmit} onClick={handleSubmit}>
+                {loading ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : <Upload className="mr-2 h-4 w-4" />}
+                {loading ? `Processing${progress ? ` ${progress}%` : ""}` : "Transcribe and analyze"}
+              </Button>
+
+              {error && <p className="text-sm text-destructive">{error}</p>}
+            </CardContent>
+          </Card>
+
+          <div className="space-y-6">
+            <Card>
+              <CardHeader>
+                <CardTitle>Transcript</CardTitle>
+                <CardDescription>{result ? `${result.filename} • ${result.model}` : "The cleaned transcript will appear here."}</CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-3">
+                <Textarea value={result?.transcript ?? ""} readOnly className="min-h-[240px]" placeholder="No transcript yet." />
+                <Button variant="outline" onClick={copyTranscript} disabled={!result?.transcript}>
+                  <Copy className="mr-2 h-4 w-4" /> Copy transcript
+                </Button>
+              </CardContent>
+            </Card>
+
+            {result && (
+              <div className="grid gap-6 md:grid-cols-2">
+                <Card>
+                  <CardHeader><CardTitle>Summary</CardTitle></CardHeader>
+                  <CardContent><p className="text-sm text-muted-foreground">{result.summary || "No summary returned."}</p></CardContent>
+                </Card>
+
+                <Card>
+                  <CardHeader><CardTitle>Action items</CardTitle></CardHeader>
+                  <CardContent>
+                    <ul className="list-disc space-y-2 pl-5 text-sm text-muted-foreground">
+                      {(result.action_items?.length ? result.action_items : ["No action items returned."]).map((item, index) => (
+                        <li key={`${item}-${index}`}>{item}</li>
+                      ))}
+                    </ul>
+                  </CardContent>
+                </Card>
+
+                <Card>
+                  <CardHeader><CardTitle>Topics</CardTitle></CardHeader>
+                  <CardContent className="flex flex-wrap gap-2">
+                    {(result.topics?.length ? result.topics : ["No topics returned."]).map((topic) => (
+                      <span key={topic} className="rounded-full border px-3 py-1 text-xs text-muted-foreground">{topic}</span>
+                    ))}
+                  </CardContent>
+                </Card>
+
+                <Card>
+                  <CardHeader><CardTitle>Timestamp chunks</CardTitle></CardHeader>
+                  <CardContent className="max-h-72 overflow-auto space-y-3 text-sm text-muted-foreground">
+                    {result.chunks?.map((chunk, index) => (
+                      <div key={`${chunk.start}-${index}`} className="rounded-lg border p-3">
+                        <p className="font-mono text-xs">{chunk.start.toFixed(2)}s → {chunk.end.toFixed(2)}s</p>
+                        <p className="mt-1">{chunk.text}</p>
+                      </div>
+                    ))}
+                  </CardContent>
+                </Card>
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Implements the Devonn.AI Speech Intelligence integration into the main app.

### Backend
- Adds `backend/app/routers/speech.py` with:
  - `GET /api/speech/health`
  - `POST /api/speech/transcribe`
- Adds typed response models in `backend/app/models/speech.py`.
- Registers the router under the existing `/api` proxy registry.
- Adds server-side configuration for:
  - `SPEECH_INTELLIGENCE_BASE_URL`
  - `SPEECH_INTELLIGENCE_API_KEY`
  - `SPEECH_INTELLIGENCE_TIMEOUT_SECONDS`
  - `SPEECH_INTELLIGENCE_MAX_UPLOAD_MB`

### Frontend
- Adds `src/api/speech/speechApi.ts` multipart upload client.
- Adds `src/pages/SpeechIntelligence.tsx` upload/review page.
- Wires route `/intelligence/speech` in `src/App.tsx`.

### Docs
- Adds `docs/SPEECH_INTELLIGENCE_IMPLEMENTATION.md` with deployment wiring and service contract.

## Runtime notes

This expects the separate Speech Intelligence microservice to expose:

- `GET /health`
- `POST /api/speech/transcribe`

Backend env vars required before production use:

```bash
SPEECH_INTELLIGENCE_BASE_URL=https://speech-api.devonn.ai
SPEECH_INTELLIGENCE_API_KEY=<shared-service-token>
SPEECH_INTELLIGENCE_TIMEOUT_SECONDS=900
SPEECH_INTELLIGENCE_MAX_UPLOAD_MB=250
```

## Why this design

Whisper Large V3 and Distil-Whisper are kept in a separate service so transcription can scale independently from the main Devonn backend, chat, RAG, admin, and orchestration layers.