### PR TITLE
Add isolated PersonaLive avatar stack

### DIFF
--- a/deploy/personalive/.env.example
+++ b/deploy/personalive/.env.example
@@ -1,0 +1,10 @@
+# Devonn.AI PersonaLive stack
+# Copy this file to .env and fill in only the values you need.
+
+# Optional: used by avatar-gateway when calling the Devonn orchestrator.
+DEVONN_API_KEY=
+ORCHESTRATOR_URL=http://host.docker.internal:8000
+
+# Optional: reserved for future voice/avatar flows.
+OPENAI_API_KEY=
+ELEVENLABS_API_KEY=

--- a/deploy/personalive/Dockerfile.gateway
+++ b/deploy/personalive/Dockerfile.gateway
@@ -1,0 +1,20 @@
+FROM python:3.11-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PORT=8100
+
+WORKDIR /app
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends curl \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY requirements.gateway.txt ./requirements.gateway.txt
+RUN pip install --no-cache-dir -r requirements.gateway.txt
+
+COPY gateway ./gateway
+
+EXPOSE 8100
+
+CMD ["uvicorn", "gateway.main:app", "--host", "0.0.0.0", "--port", "8100"]

--- a/deploy/personalive/README.md
+++ b/deploy/personalive/README.md
@@ -1,0 +1,75 @@
+# Devonn.AI PersonaLive Avatar Stack
+
+This folder contains an isolated Docker Compose stack for running PersonaLive beside Devonn.AI without touching the main app deployment.
+
+## Services
+
+- `personalive` — GPU-enabled PersonaLive all-in-one container exposed on port `7870`.
+- `avatar-gateway` — small FastAPI gateway exposed on port `8100` for Devonn-facing health checks and avatar session forwarding.
+
+## Files
+
+- `docker-compose.yml` — clean Compose stack.
+- `Dockerfile.gateway` — gateway image definition.
+- `requirements.gateway.txt` — gateway Python dependencies.
+- `gateway/main.py` — FastAPI gateway.
+- `.env.example` — safe environment template.
+
+## Run locally
+
+```bash
+cd deploy/personalive
+cp .env.example .env
+docker compose up --build
+```
+
+Health checks:
+
+```bash
+curl http://localhost:7870/health
+curl http://localhost:8100/health
+```
+
+## GPU requirement
+
+The PersonaLive service reserves one NVIDIA GPU:
+
+```yaml
+deploy:
+  resources:
+    reservations:
+      devices:
+        - driver: nvidia
+          count: 1
+          capabilities: [gpu]
+```
+
+For local Docker Compose, make sure the NVIDIA Container Toolkit is installed and Docker can access the GPU.
+
+## Devonn integration path
+
+The gateway reads:
+
+- `PERSONALIVE_URL`, default `http://personalive:7870`
+- `ORCHESTRATOR_URL`, default `http://host.docker.internal:8000`
+- `DEVONN_API_KEY`, optional
+- `OPENAI_API_KEY`, optional
+- `ELEVENLABS_API_KEY`, optional
+
+The initial gateway endpoint is intentionally conservative:
+
+```http
+POST /avatar/session
+```
+
+It forwards to:
+
+```http
+POST ${PERSONALIVE_URL}/api/avatar/session
+```
+
+If PersonaLive uses a different endpoint shape, update `gateway/main.py` after confirming the upstream API.
+
+## Safety notes
+
+Do not commit `.env` or real API keys. Use `.env.example` only as a template.

--- a/deploy/personalive/docker-compose.yml
+++ b/deploy/personalive/docker-compose.yml
@@ -1,0 +1,56 @@
+version: "3.8"
+
+services:
+  personalive:
+    image: neosun/personalive:allinone
+    container_name: devonn-personalive
+    ports:
+      - "7870:7870"
+    environment:
+      PORT: "7870"
+      HOST: "0.0.0.0"
+      GPU_IDLE_TIMEOUT: "600"
+      ACCELERATION: "xformers"
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: 1
+              capabilities: [gpu]
+    volumes:
+      - personalive-data:/app/output
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:7870/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 60s
+
+  avatar-gateway:
+    build:
+      context: .
+      dockerfile: Dockerfile.gateway
+    container_name: devonn-avatar-gateway
+    ports:
+      - "8100:8100"
+    environment:
+      PERSONALIVE_URL: "http://personalive:7870"
+      ELEVENLABS_API_KEY: "${ELEVENLABS_API_KEY:-}"
+      OPENAI_API_KEY: "${OPENAI_API_KEY:-}"
+      DEVONN_API_KEY: "${DEVONN_API_KEY:-}"
+      ORCHESTRATOR_URL: "${ORCHESTRATOR_URL:-http://host.docker.internal:8000}"
+    depends_on:
+      personalive:
+        condition: service_healthy
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8100/health"]
+      interval: 15s
+      timeout: 5s
+      retries: 3
+      start_period: 30s
+
+volumes:
+  personalive-data:

--- a/deploy/personalive/gateway/__init__.py
+++ b/deploy/personalive/gateway/__init__.py
@@ -1,0 +1,1 @@
+"""Devonn.AI PersonaLive avatar gateway."""

--- a/deploy/personalive/gateway/main.py
+++ b/deploy/personalive/gateway/main.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import os
+from typing import Any, Dict
+
+import httpx
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel, Field
+
+
+PERSONALIVE_URL = os.getenv("PERSONALIVE_URL", "http://personalive:7870").rstrip("/")
+ORCHESTRATOR_URL = os.getenv("ORCHESTRATOR_URL", "http://host.docker.internal:8000").rstrip("/")
+DEVONN_API_KEY = os.getenv("DEVONN_API_KEY", "")
+
+app = FastAPI(title="Devonn Avatar Gateway", version="0.1.0")
+
+
+class AvatarRequest(BaseModel):
+    prompt: str = Field(..., min_length=1, max_length=4000)
+    voice_id: str | None = None
+    avatar_id: str | None = None
+    metadata: Dict[str, Any] = Field(default_factory=dict)
+
+
+@app.get("/health")
+async def health() -> Dict[str, Any]:
+    personalive_ok = False
+    try:
+        async with httpx.AsyncClient(timeout=3.0) as client:
+            response = await client.get(f"{PERSONALIVE_URL}/health")
+            personalive_ok = response.status_code < 500
+    except Exception:
+        personalive_ok = False
+
+    return {
+        "status": "ok" if personalive_ok else "degraded",
+        "personalive_url": PERSONALIVE_URL,
+        "personalive_ok": personalive_ok,
+        "orchestrator_url": ORCHESTRATOR_URL,
+    }
+
+
+@app.post("/avatar/session")
+async def create_avatar_session(payload: AvatarRequest) -> Dict[str, Any]:
+    """Create an avatar session request envelope.
+
+    This endpoint is intentionally conservative: it validates and normalizes the
+    request, then forwards it to PersonaLive when the upstream exposes a compatible
+    API. If the upstream endpoint differs, this gateway returns a clear 502 rather
+    than hiding the failure.
+    """
+    request_body = payload.model_dump(exclude_none=True)
+    headers: Dict[str, str] = {}
+    if DEVONN_API_KEY:
+        headers["X-Devonn-API-Key"] = DEVONN_API_KEY
+
+    try:
+        async with httpx.AsyncClient(timeout=60.0) as client:
+            response = await client.post(
+                f"{PERSONALIVE_URL}/api/avatar/session",
+                json=request_body,
+                headers=headers,
+            )
+    except httpx.RequestError as exc:
+        raise HTTPException(status_code=502, detail=f"PersonaLive upstream unavailable: {exc}") from exc
+
+    if response.status_code >= 400:
+        raise HTTPException(
+            status_code=502,
+            detail={
+                "message": "PersonaLive upstream rejected avatar session request",
+                "upstream_status": response.status_code,
+                "upstream_excerpt": response.text[:500],
+            },
+        )
+
+    try:
+        upstream_payload = response.json()
+    except ValueError:
+        upstream_payload = {"raw": response.text}
+
+    return {
+        "status": "accepted",
+        "upstream": upstream_payload,
+        "metadata": payload.metadata,
+    }

--- a/deploy/personalive/requirements.gateway.txt
+++ b/deploy/personalive/requirements.gateway.txt
@@ -1,0 +1,4 @@
+fastapi>=0.115.0,<1
+httpx>=0.27.0,<1
+pydantic>=2.7.0,<3
+uvicorn[standard]>=0.30.0,<1


### PR DESCRIPTION
## Summary

Adds an isolated PersonaLive/avatar gateway stack under `deploy/personalive/`.

### Added
- Clean `docker-compose.yml` for PersonaLive + avatar gateway.
- GPU reservation for PersonaLive.
- FastAPI `avatar-gateway` service with `/health` and conservative `/avatar/session` forwarding.
- Gateway Dockerfile and Python requirements.
- `.env.example` with no secrets.
- README with run instructions, health checks, GPU notes, and integration notes.

## Safety

This does not modify the primary app runtime, deployment workflow, or root Docker stack. It is isolated under `deploy/personalive/` to avoid disturbing current green CI/deployment state.

## Notes

The pasted compose snippet had malformed YAML because the CI remediation report text was inserted into the `ports:` block. This PR cleans the Compose structure and documents how to run the stack safely.