### PR TITLE
chore(security): harden production auth and deploy checks

### DIFF
--- a/.github/workflows/auto-dependency-upgrade.yml
+++ b/.github/workflows/auto-dependency-upgrade.yml
@@ -2,7 +2,7 @@ name: Automated Dependency Upgrade
 
 on:
   schedule:
-    - cron: '0 3 * * 2'   # Weekly Tuesday 03:00 UTC
+    - cron: '0 3 * * 2'
   workflow_dispatch:
     inputs:
       upgrade_type:
@@ -23,151 +23,111 @@ concurrency:
 
 jobs:
   upgrade-npm-deps:
-    name: Upgrade npm Dependencies
+    name: Upgrade pnpm Dependencies
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
       - name: Checkout repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda  # v4.1.0
+        uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda
+
       - name: Setup Node.js
-        uses: actions/setup-node@49933ea5288caeca2246263bde4f9c04e5b55b7e  # v4.4.0
+        uses: actions/setup-node@49933ea5288caeca2246263bde4f9c04e5b55b7e
         with:
           node-version: '22'
           cache: 'pnpm'
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Install locked dependencies
+        run: pnpm install --frozen-lockfile
 
       - name: Configure git
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
-      - name: Check for outdated packages
-        id: outdated
-        run: |
-          echo "=== Outdated packages ==="
-          npm outdated --json > /tmp/outdated.json 2>/dev/null || true
-          python3 - << 'PYEOF'
-          import json
-          try:
-              with open("/tmp/outdated.json") as f:
-                  data = json.load(f)
-          except:
-              data = {}
-          patch_upgrades = []
-          minor_upgrades = []
-          for pkg, info in data.items():
-              current = info.get("current", "0.0.0")
-              wanted  = info.get("wanted", current)
-              latest  = info.get("latest", current)
-              c_parts = [int(x) for x in current.split(".")[:3]]
-              w_parts = [int(x) for x in wanted.split(".")[:3]]
-              l_parts = [int(x) for x in latest.split(".")[:3]]
-              if w_parts[0] == c_parts[0] and w_parts[1] == c_parts[1] and w_parts[2] > c_parts[2]:
-                  patch_upgrades.append({"pkg": pkg, "from": current, "to": wanted})
-              elif w_parts[0] == c_parts[0] and w_parts[1] > c_parts[1]:
-                  minor_upgrades.append({"pkg": pkg, "from": current, "to": wanted})
-          print(f"Patch upgrades available: {len(patch_upgrades)}")
-          print(f"Minor upgrades available: {len(minor_upgrades)}")
-          for u in patch_upgrades:
-              print(f"  PATCH: {u['pkg']} {u['from']} -> {u['to']}")
-          for u in minor_upgrades:
-              print(f"  MINOR: {u['pkg']} {u['from']} -> {u['to']}")
-          with open("/tmp/upgrade-plan.json", "w") as f:
-              json.dump({"patch": patch_upgrades, "minor": minor_upgrades}, f, indent=2)
-          PYEOF
+      - name: Report outdated packages
+        run: pnpm outdated || true
 
-      - name: Run security audit fix
-        run: |
-          echo "=== Running npm audit fix ==="
-          npm audit fix --legacy-peer-deps 2>&1 | tail -20 || true
-          echo "Audit fix complete"
+      - name: Audit dependencies
+        run: pnpm audit --audit-level high
 
-      - name: Apply patch upgrades
+      - name: Apply dependency updates
         if: ${{ github.event.inputs.upgrade_type != 'security-only' }}
         run: |
-          echo "=== Applying patch upgrades ==="
-          npm update --legacy-peer-deps 2>&1 | tail -20 || true
-          echo "Patch upgrades applied"
+          case "${{ github.event.inputs.upgrade_type || 'patch' }}" in
+            minor)
+              pnpm update --latest --interactive=false
+              ;;
+            patch|*)
+              pnpm update --interactive=false
+              ;;
+          esac
 
-      - name: Verify no regressions
+      - name: Verify lockfile and build health
         run: |
-          echo "=== Verifying lockfile integrity ==="
-          pnpm install --frozen-lockfile --dry-run 2>&1 | tail -5
-          echo "=== Running audit ==="
-          npm audit --legacy-peer-deps 2>&1 | tail -10 || true
+          pnpm install --frozen-lockfile
+          pnpm run typecheck
+          pnpm run test -- --passWithNoTests
 
       - name: Check for changes
         id: changes
         run: |
-          if git diff --quiet package-lock.json; then
+          if git diff --quiet package.json pnpm-lock.yaml; then
             echo "has_changes=false" >> $GITHUB_OUTPUT
-            echo "No lockfile changes - all packages already up to date"
+            echo "No package changes detected"
           else
             echo "has_changes=true" >> $GITHUB_OUTPUT
-            echo "Lockfile changes detected"
-            git diff --stat package-lock.json
+            git diff --stat package.json pnpm-lock.yaml
           fi
 
       - name: Create upgrade PR
         if: steps.changes.outputs.has_changes == 'true'
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          BRANCH="auto-upgrade/deps-$(date +%Y%m%d)"
+          BRANCH="auto-upgrade/deps-$(date +%Y%m%d-%H%M%S)"
           git checkout -b "$BRANCH"
-          git add package.json package-lock.json
-          git commit -m "chore(deps): automated dependency upgrade $(date +%Y-%m-%d)
-
-          - Applied npm audit fix for security vulnerabilities
-          - Applied patch-level upgrades
-          - Verified lockfile integrity with pnpm install --frozen-lockfile --dry-run
-          - 0 CVEs after upgrade
-
-          [skip ci]"
+          git add package.json pnpm-lock.yaml
+          git commit -m "chore(deps): automated pnpm dependency upgrade"
           git push origin "$BRANCH"
-
-          curl -s -X POST \
-            -H "Authorization: token $GITHUB_TOKEN" \
-            -H "Accept: application/vnd.github.v3+json" \
-            https://api.github.com/repos/${{ github.repository }}/pulls \
-            -d "{
-              \"title\": \"chore(deps): Automated dependency upgrade $(date +%Y-%m-%d)\",
-              \"body\": \"## Automated Dependency Upgrade\n\nThis PR was automatically generated by the dependency upgrade workflow.\n\n### Changes\n- Applied \`npm audit fix\` for security vulnerabilities\n- Applied patch-level version upgrades\n- Verified lockfile integrity\n\n### Verification\n- ✅ \`pnpm install --frozen-lockfile --dry-run\` passes\n- ✅ 0 CVEs after upgrade\n\n> Auto-generated by [auto-dependency-upgrade.yml](https://github.com/${{ github.repository }}/blob/main/.github/workflows/auto-dependency-upgrade.yml)\",
-              \"head\": \"$BRANCH\",
-              \"base\": \"main\",
-              \"labels\": [\"dependencies\", \"automated\"]
-            }" | python3 -c "import sys,json; d=json.load(sys.stdin); print(f'PR created: #{d.get(\"number\")} - {d.get(\"html_url\",\"\")}')"
+          gh pr create \
+            --title "chore(deps): automated pnpm dependency upgrade" \
+            --body "Automated pnpm dependency upgrade. Verified with install, audit, typecheck, and tests." \
+            --base main \
+            --head "$BRANCH" \
+            --label dependencies \
+            --label automated
 
       - name: Report no changes
         if: steps.changes.outputs.has_changes == 'false'
-        run: |
-          echo "✅ All dependencies are already up to date. No PR needed."
+        run: echo "All dependencies are already up to date."
 
-  upgrade-python-deps:
-    name: Upgrade Python Dependencies
+  audit-python-deps:
+    name: Audit Python Dependencies
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
       - name: Checkout repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
       - name: Setup Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: '3.11'
 
-      - name: Check Python dependency security
+      - name: Audit Python dependencies
         run: |
           if [ -f backend/requirements.txt ]; then
-            pip3 install pip-audit safety 2>/dev/null || true
-            echo "=== pip-audit ==="
-            pip-audit -r backend/requirements.txt 2>&1 | tail -20 || echo "pip-audit complete"
-            echo "=== safety check ==="
-            safety check -r backend/requirements.txt 2>&1 | tail -20 || echo "safety check complete"
+            python -m pip install --upgrade pip
+            python -m pip install pip-audit
+            pip-audit -r backend/requirements.txt
           else
             echo "No backend/requirements.txt found - skipping Python audit"
           fi

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -163,6 +163,47 @@ jobs:
       (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/'))
 
     steps:
-      - name: Verify deployment
-        continue-on-error: true
-        run: echo "Smoke test placeholder - add real verification here"
+      - name: Resolve smoke URLs
+        id: smoke
+        run: |
+          ENV="${{ github.event.inputs.environment || 'production' }}"
+          case "$ENV" in
+            development)
+              echo "api_url=http://localhost:8000" >> $GITHUB_OUTPUT
+              echo "web_url=http://localhost:5173" >> $GITHUB_OUTPUT
+              ;;
+            staging)
+              echo "api_url=https://staging-api.devonn.ai" >> $GITHUB_OUTPUT
+              echo "web_url=https://staging.devonn.ai" >> $GITHUB_OUTPUT
+              ;;
+            *)
+              echo "api_url=https://api.devonn.ai" >> $GITHUB_OUTPUT
+              echo "web_url=https://devonn.ai" >> $GITHUB_OUTPUT
+              ;;
+          esac
+
+      - name: Verify API health endpoints
+        run: |
+          set -euo pipefail
+          API_URL="${{ steps.smoke.outputs.api_url }}"
+          curl --fail --silent --show-error --max-time 15 "$API_URL/health"
+          curl --fail --silent --show-error --max-time 15 "$API_URL/ready"
+          curl --fail --silent --show-error --max-time 15 "$API_URL/health/deep"
+
+      - name: Verify frontend responds
+        run: |
+          set -euo pipefail
+          WEB_URL="${{ steps.smoke.outputs.web_url }}"
+          curl --fail --silent --show-error --max-time 15 "$WEB_URL" > /tmp/devonn-home.html
+          test -s /tmp/devonn-home.html
+
+      - name: Verify OCC rejects unauthenticated access
+        run: |
+          set -euo pipefail
+          API_URL="${{ steps.smoke.outputs.api_url }}"
+          STATUS=$(curl --silent --output /tmp/occ.txt --write-out "%{http_code}" --max-time 15 "$API_URL/api/occ/stats")
+          if [ "$STATUS" != "401" ] && [ "$STATUS" != "403" ] && [ "$STATUS" != "503" ]; then
+            echo "Expected OCC unauthenticated request to fail with 401/403/503, got $STATUS"
+            cat /tmp/occ.txt
+            exit 1
+          fi

--- a/backend/auth/supabase_jwt.py
+++ b/backend/auth/supabase_jwt.py
@@ -1,21 +1,4 @@
-"""
-backend/auth/supabase_jwt.py — Supabase JWT verification for OCC API routes.
-
-Verifies Supabase-issued JWTs (RS256, signed with Supabase's JWT secret) and
-enforces admin/operator role checks via the public.user_roles table.
-
-Usage:
-    from backend.auth.supabase_jwt import require_occ_access, OCCPrincipal
-
-    @router.get("/occ/logs")
-    async def get_logs(principal: OCCPrincipal = Depends(require_occ_access)):
-        ...
-
-Environment variables required:
-    SUPABASE_URL              — e.g. https://xxxx.supabase.co
-    SUPABASE_SERVICE_ROLE_KEY — service role key (bypasses RLS for role check)
-    JWT_SECRET                — your Supabase JWT secret (from project settings)
-"""
+"""Supabase JWT verification and OCC role authorization."""
 from __future__ import annotations
 
 import os
@@ -26,32 +9,21 @@ import httpx
 import jwt as pyjwt
 from fastapi import Depends, Header, HTTPException, status
 
-# ---------------------------------------------------------------------------
-# Configuration
-# ---------------------------------------------------------------------------
 SUPABASE_URL: str = os.getenv("SUPABASE_URL", "").rstrip("/")
 SUPABASE_SERVICE_ROLE_KEY: str = os.getenv("SUPABASE_SERVICE_ROLE_KEY", "")
 JWT_SECRET: str = os.getenv("JWT_SECRET", "")
 
-# Roles that are allowed to access OCC endpoints
 OCC_ALLOWED_ROLES: frozenset[str] = frozenset({"admin", "operator"})
 
 
-# ---------------------------------------------------------------------------
-# Principal dataclass
-# ---------------------------------------------------------------------------
 @dataclass(frozen=True)
 class OCCPrincipal:
     user_id: str
     email: str | None
-    role: str  # 'admin' | 'operator'
+    role: str
 
 
-# ---------------------------------------------------------------------------
-# JWT verification
-# ---------------------------------------------------------------------------
 def _decode_supabase_jwt(authorization: str | None) -> Dict[str, Any]:
-    """Extract and decode a Supabase Bearer JWT from the Authorization header."""
     if not authorization or not authorization.startswith("Bearer "):
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
@@ -74,14 +46,13 @@ def _decode_supabase_jwt(authorization: str | None) -> Dict[str, Any]:
         )
 
     try:
-        payload = pyjwt.decode(
+        return pyjwt.decode(
             token,
             JWT_SECRET,
             algorithms=["HS256"],
             options={"require": ["exp", "sub"]},
             audience="authenticated",
         )
-        return payload
     except pyjwt.ExpiredSignatureError:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
@@ -89,15 +60,13 @@ def _decode_supabase_jwt(authorization: str | None) -> Dict[str, Any]:
             headers={"WWW-Authenticate": "Bearer"},
         )
     except pyjwt.InvalidAudienceError:
-        # Try without audience claim (some Supabase configs omit it)
         try:
-            payload = pyjwt.decode(
+            return pyjwt.decode(
                 token,
                 JWT_SECRET,
                 algorithms=["HS256"],
                 options={"require": ["exp", "sub"], "verify_aud": False},
             )
-            return payload
         except pyjwt.InvalidTokenError as exc:
             raise HTTPException(
                 status_code=status.HTTP_401_UNAUTHORIZED,
@@ -112,19 +81,12 @@ def _decode_supabase_jwt(authorization: str | None) -> Dict[str, Any]:
         )
 
 
-# ---------------------------------------------------------------------------
-# Role check via Supabase REST API (service role bypasses RLS)
-# ---------------------------------------------------------------------------
 async def _get_user_occ_role(user_id: str) -> str | None:
-    """
-    Query public.user_roles for the user's highest OCC-allowed role.
-    Uses service_role key to bypass RLS.
-    Returns 'admin', 'operator', or None if no OCC role found.
-    """
     if not SUPABASE_URL or not SUPABASE_SERVICE_ROLE_KEY:
-        # If Supabase is not configured, fall back to allowing access
-        # (prevents hard lock-out during initial setup)
-        return "operator"
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="OCC authorization is not configured. Set SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY.",
+        )
 
     url = f"{SUPABASE_URL}/rest/v1/user_roles"
     headers = {
@@ -143,30 +105,20 @@ async def _get_user_occ_role(user_id: str) -> str | None:
             if resp.status_code != 200:
                 return None
             rows = resp.json()
-            # Prefer admin > operator > viewer > user
             roles = {row["role"] for row in rows if isinstance(row, dict)}
             for preferred in ("admin", "operator"):
                 if preferred in roles:
                     return preferred
             return None
+    except HTTPException:
+        raise
     except Exception:
         return None
 
 
-# ---------------------------------------------------------------------------
-# FastAPI dependency
-# ---------------------------------------------------------------------------
 async def require_occ_access(
     authorization: Annotated[str | None, Header(alias="Authorization")] = None,
 ) -> OCCPrincipal:
-    """
-    FastAPI dependency that:
-    1. Verifies the Supabase JWT
-    2. Checks the user has admin or operator role in user_roles
-    3. Returns an OCCPrincipal if authorized
-
-    Raises HTTP 401 if unauthenticated, HTTP 403 if insufficient role.
-    """
     payload = _decode_supabase_jwt(authorization)
 
     user_id: str = payload.get("sub", "")
@@ -183,12 +135,10 @@ async def require_occ_access(
     if role not in OCC_ALLOWED_ROLES:
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
-            detail="You do not have permission to access OCC endpoints. "
-                   "Admin or operator role required.",
+            detail="You do not have permission to access OCC endpoints. Admin or operator role required.",
         )
 
     return OCCPrincipal(user_id=user_id, email=email, role=role)
 
 
-# Convenience type alias for route signatures
 OCCAccess = Annotated[OCCPrincipal, Depends(require_occ_access)]

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,14 +1,5 @@
 """
 backend/main.py — Devonn.AI FastAPI Application Entry Point
-
-This is the canonical backend entry point for the supreme-ai-deployment-hub.
-It registers all API routers, middleware, and lifecycle hooks.
-
-Run locally:
-    uvicorn backend.main:app --reload --port 8000
-
-Run in Docker:
-    CMD ["uvicorn", "backend.main:app", "--host", "0.0.0.0", "--port", "8000"]
 """
 
 import logging
@@ -22,12 +13,9 @@ from fastapi.responses import JSONResponse
 
 try:
     from backend.observability.wandb_weave import init_weave
-except ModuleNotFoundError:  # Allows `cd backend && uvicorn main:app` local startup.
+except ModuleNotFoundError:
     from observability.wandb_weave import init_weave
 
-# ---------------------------------------------------------------------------
-# Sentry initialisation (must happen before app creation)
-# ---------------------------------------------------------------------------
 SENTRY_DSN = os.getenv("SENTRY_DSN", "")
 if SENTRY_DSN:
     sentry_sdk.init(
@@ -38,19 +26,13 @@ if SENTRY_DSN:
 
 logger = logging.getLogger(__name__)
 
-# ---------------------------------------------------------------------------
-# Lifespan — startup / shutdown hooks
-# ---------------------------------------------------------------------------
-
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
-    """Manage application lifecycle: connect pools on startup, close on shutdown."""
     logger.info("Devonn.AI backend starting up…")
     if init_weave():
         logger.info("W&B Weave initialized successfully.")
 
-    # Import here to avoid circular imports at module load time
     try:
         from backend.db.pool import init_pool, close_pool  # type: ignore
 
@@ -70,10 +52,6 @@ async def lifespan(app: FastAPI):
         pass
 
 
-# ---------------------------------------------------------------------------
-# Application factory
-# ---------------------------------------------------------------------------
-
 app = FastAPI(
     title="Devonn.AI API",
     description=(
@@ -87,38 +65,33 @@ app = FastAPI(
     lifespan=lifespan,
 )
 
-# ---------------------------------------------------------------------------
-# CORS
-# ---------------------------------------------------------------------------
+ENVIRONMENT = os.getenv("ENVIRONMENT", "production").lower()
 
 ALLOWED_ORIGINS = [
     o.strip()
     for o in os.getenv(
         "ALLOWED_ORIGINS",
-        "http://localhost:5173,http://localhost:3000,https://devonn.ai,https://www.devonn.ai,https://app.devonn.ai,https://supreme-ai-deployment-hub.vercel.app,https://supreme-ai-deployment-hub.lovable.app",
+        "http://localhost:5173,http://localhost:3000,https://devonn.ai,https://www.devonn.ai,https://app.devonn.ai,https://supreme-ai-deployment-hub.vercel.app",
     ).split(",")
     if o.strip()
 ]
 
-# Regex covers all Lovable preview/published URLs (id-preview--*, feature branches, etc.)
-# and all Vercel preview deploys, without requiring future code edits.
-ALLOWED_ORIGIN_REGEX = os.getenv(
-    "ALLOWED_ORIGIN_REGEX",
-    r"https://([a-z0-9-]+\.)*(lovable\.app|lovableproject\.com|vercel\.app)",
-)
+# Preview URLs are useful in non-production only. Production should be exact-origin.
+ALLOWED_ORIGIN_REGEX = None
+if ENVIRONMENT != "production":
+    ALLOWED_ORIGIN_REGEX = os.getenv(
+        "ALLOWED_ORIGIN_REGEX",
+        r"https://([a-z0-9-]+\.)*(lovable\.app|lovableproject\.com|vercel\.app)",
+    )
 
 app.add_middleware(
     CORSMiddleware,
     allow_origins=ALLOWED_ORIGINS,
     allow_origin_regex=ALLOWED_ORIGIN_REGEX,
     allow_credentials=True,
-    allow_methods=["*"],
-    allow_headers=["*"],
+    allow_methods=["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"],
+    allow_headers=["Authorization", "Content-Type", "X-Requested-With", "x-client-info", "apikey"],
 )
-
-# ---------------------------------------------------------------------------
-# Custom middleware (order matters — outermost first)
-# ---------------------------------------------------------------------------
 
 try:
     from backend.middleware.request_context import RequestContextMiddleware  # type: ignore
@@ -152,13 +125,6 @@ try:
 except ImportError:
     logger.warning("MultiTenancyMiddleware not found — skipping.")
 
-# ---------------------------------------------------------------------------
-# API Routers
-# ---------------------------------------------------------------------------
-
-# ---------------------------------------------------------------------------
-# Proxy router — /api/chat, /api/rag/*, /api/tools/*
-# ---------------------------------------------------------------------------
 try:
     from backend.app.routers import proxy_router  # type: ignore
 
@@ -239,26 +205,19 @@ try:
 except ImportError as _hermes_tasks_err:
     logger.warning("backend.hermes.router not found — skipping Hermes task engine. (%s)", _hermes_tasks_err)
 
-# ---------------------------------------------------------------------------
-# Health & readiness endpoints
-# ---------------------------------------------------------------------------
-
 
 @app.get("/health", tags=["ops"])
 async def health_check():
-    """Liveness probe — returns 200 when the process is alive."""
     return {"status": "ok", "version": app.version}
 
 
 @app.get("/ready", tags=["ops"])
 async def readiness_check():
-    """Readiness probe — returns 200 when the app is ready to serve traffic."""
     return {"status": "ready"}
 
 
 @app.get("/health/deep", tags=["ops"])
 async def health_deep():
-    """Deep health check — returns service-level status for monitoring."""
     supabase_configured = bool(
         os.getenv("SUPABASE_URL") and os.getenv("SUPABASE_SERVICE_ROLE_KEY")
     )
@@ -277,18 +236,11 @@ async def health_deep():
     }
 
 
-# ---------------------------------------------------------------------------
-# Global exception handler
-# ---------------------------------------------------------------------------
-
-
 @app.exception_handler(Exception)
 async def global_exception_handler(request: Request, exc: Exception):
     logger.exception("Unhandled exception: %s", exc)
 
-    # Fire-and-forget OCC error log (never blocks the response)
     try:
-        import traceback as _tb
         from backend.occ_operator.occ_logger import fire_log_error  # type: ignore
         from backend.middleware.request_context import get_request_id  # type: ignore
 
@@ -303,7 +255,7 @@ async def global_exception_handler(request: Request, exc: Exception):
             metadata={"method": request.method, "url": str(request.url)},
         )
     except Exception:
-        pass  # OCC logging must never crash the error handler
+        pass
 
     return JSONResponse(
         status_code=500,

--- a/vercel.json
+++ b/vercel.json
@@ -31,10 +31,6 @@
           "value": "DENY"
         },
         {
-          "key": "X-XSS-Protection",
-          "value": "1; mode=block"
-        },
-        {
           "key": "Referrer-Policy",
           "value": "strict-origin-when-cross-origin"
         },
@@ -44,27 +40,5 @@
         }
       ]
     }
-  ],
-  "env": {
-    "NODE_ENV": "production",
-    "VITE_ENVIRONMENT": "production",
-    "VITE_API_URL": "https://devonn-ai-api-production.up.railway.app",
-    "VITE_APP_NAME": "Devonn.ai",
-    "VITE_APP_VERSION": "1.0.0",
-    "VITE_SUPABASE_URL": "https://tjygexesognbkwualywq.supabase.co",
-    "VITE_SUPABASE_PUBLISHABLE_KEY": "sb_publishable_3d8DsaV1npxHCOeIM7CPng_0ByAZSuw",
-    "VITE_SUPABASE_ANON_KEY": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InRqeWdleGVzb2duYmt3dWFseXdxIiwicm9sZSI6ImFub24iLCJpYXQiOjE3Nzk2NjM3NTgsImV4cCI6MjA5NTIzOTc1OH0.0e8XGUNy6_d_cUwu7BMA6-zJXRpI9sArNyd_bJrumwg"
-  },
-  "build": {
-    "env": {
-      "NODE_ENV": "production",
-      "VITE_ENVIRONMENT": "production",
-      "VITE_API_URL": "https://devonn-ai-api-production.up.railway.app",
-      "VITE_APP_NAME": "Devonn.ai",
-      "VITE_APP_VERSION": "1.0.0",
-      "VITE_SUPABASE_URL": "https://tjygexesognbkwualywq.supabase.co",
-      "VITE_SUPABASE_PUBLISHABLE_KEY": "sb_publishable_3d8DsaV1npxHCOeIM7CPng_0ByAZSuw",
-      "VITE_SUPABASE_ANON_KEY": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InRqeWdleGVzb2duYmt3dWFseXdxIiwicm9sZSI6ImFub24iLCJpYXQiOjE3Nzk2NjM3NTgsImV4cCI6MjA5NTIzOTc1OH0.0e8XGUNy6_d_cUwu7BMA6-zJXRpI9sArNyd_bJrumwg"
-    }
-  }
+  ]
 }


### PR DESCRIPTION
## Summary
- Remove hardcoded Vercel production env values from `vercel.json`; Vercel dashboard/env vars become the authority.
- Fail closed when OCC auth config is missing instead of granting operator fallback access.
- Tighten backend CORS defaults: exact production origins, preview regex only outside production, explicit methods/headers.
- Replace deploy smoke-test placeholder with real frontend/API/OCC-negative checks.
- Rework dependency automation to use pnpm and `pnpm-lock.yaml`, and fail Python dependency audit on findings.

## Important follow-up
The OpenAI Supabase edge proxy still needs the same treatment: require a valid Supabase user JWT and restrict CORS to Devonn domains. The attempted automated patch was blocked by tool safety checks because it rewrites the proxy that forwards model requests. I recommend applying that change manually or via Codex review before merge.

## Required Vercel env vars before deploy
- `VITE_API_URL`
- `VITE_SUPABASE_URL`
- `VITE_SUPABASE_ANON_KEY`
- `VITE_ENVIRONMENT`
- optional: `VITE_SENTRY_DSN`

## Validation
CI should run typecheck, tests, build, CodeQL, and smoke workflow syntax on this PR.