### PR TITLE
Mount DKOS Knowledge API in FastAPI runtime

### DIFF
--- a/backend/knowledge/__init__.py
+++ b/backend/knowledge/__init__.py
@@ -1,0 +1,1 @@
+"""DKOS Knowledge API package."""

--- a/backend/knowledge/router.py
+++ b/backend/knowledge/router.py
@@ -1,0 +1,221 @@
+"""DKOS Knowledge API router.
+
+Exposes generated D3VONN Knowledge Operating System artifacts through FastAPI.
+
+Expected artifact directory:
+    DKOS_ARTIFACT_DIR=/path/to/dkos/artifacts
+
+Required files:
+    dkos_index.json
+
+Optional files:
+    dkos_graph.json
+    dkos_observability_report.md
+    dkos_embedding_manifest.json
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+from functools import lru_cache
+from pathlib import Path
+from typing import Any
+
+from fastapi import APIRouter, HTTPException, Query
+from pydantic import BaseModel, Field
+
+router = APIRouter(prefix="/api/knowledge", tags=["knowledge"])
+
+
+class ContextRequest(BaseModel):
+    query: str = Field(..., min_length=1)
+    agent: str = "Hermes"
+    limit: int = Field(default=10, ge=1, le=50)
+
+
+class KnowledgeStore:
+    def __init__(self, artifact_dir: Path) -> None:
+        self.artifact_dir = artifact_dir
+        self.index_path = artifact_dir / "dkos_index.json"
+        self.graph_path = artifact_dir / "dkos_graph.json"
+        self.observability_path = artifact_dir / "dkos_observability_report.md"
+        self.embedding_manifest_path = artifact_dir / "dkos_embedding_manifest.json"
+
+        if not self.index_path.exists():
+            raise FileNotFoundError(f"Missing required DKOS index artifact: {self.index_path}")
+
+        self.index_payload = self._load_json(self.index_path)
+        self.graph_payload = self._load_json(self.graph_path) if self.graph_path.exists() else {"nodes": [], "edges": [], "stats": {}}
+        self.documents: list[dict[str, Any]] = self.index_payload.get("documents", [])
+        self.by_id = {doc.get("id"): doc for doc in self.documents if doc.get("id")}
+        self.by_path = {doc.get("path"): doc for doc in self.documents if doc.get("path")}
+
+    @staticmethod
+    def _load_json(path: Path) -> dict[str, Any]:
+        return json.loads(path.read_text(encoding="utf-8"))
+
+    @staticmethod
+    def _tokens(text: str) -> set[str]:
+        return {token.lower() for token in re.findall(r"[a-zA-Z0-9_]+", text)}
+
+    def status(self) -> dict[str, Any]:
+        return {
+            "status": "ready",
+            "artifact_dir": str(self.artifact_dir),
+            "documents": len(self.documents),
+            "graph_nodes": len(self.graph_payload.get("nodes", [])),
+            "graph_edges": len(self.graph_payload.get("edges", [])),
+            "artifacts": {
+                "index": self.index_path.exists(),
+                "graph": self.graph_path.exists(),
+                "observability_report": self.observability_path.exists(),
+                "embedding_manifest": self.embedding_manifest_path.exists(),
+            },
+        }
+
+    def search(self, query: str, limit: int = 10) -> list[dict[str, Any]]:
+        query_terms = self._tokens(query)
+        results: list[dict[str, Any]] = []
+
+        for doc in self.documents:
+            searchable = " ".join(
+                str(part or "")
+                for part in [
+                    doc.get("id"),
+                    doc.get("path"),
+                    doc.get("title"),
+                    doc.get("category"),
+                    " ".join(doc.get("tags") or []),
+                    " ".join(doc.get("related") or []),
+                    doc.get("summary"),
+                ]
+            )
+            overlap = query_terms & self._tokens(searchable)
+            if overlap:
+                results.append(
+                    {
+                        "id": doc.get("id"),
+                        "path": doc.get("path"),
+                        "title": doc.get("title"),
+                        "category": doc.get("category"),
+                        "tags": doc.get("tags", []),
+                        "score": len(overlap),
+                        "matches": sorted(overlap),
+                    }
+                )
+
+        results.sort(key=lambda item: item["score"], reverse=True)
+        return results[:limit]
+
+    def entity(self, identifier: str) -> dict[str, Any] | None:
+        return self.by_id.get(identifier) or self.by_path.get(identifier)
+
+    def related(self, identifier: str, limit: int = 20) -> list[dict[str, Any]]:
+        doc = self.entity(identifier)
+        if not doc:
+            return []
+
+        related_docs: list[dict[str, Any]] = []
+        seen: set[str] = set()
+
+        for rel in doc.get("related", []):
+            target = self.entity(rel)
+            if target and target.get("id") not in seen:
+                related_docs.append(target)
+                seen.add(str(target.get("id")))
+
+        category = doc.get("category")
+        tags = set(doc.get("tags", []))
+        for candidate in self.documents:
+            candidate_id = str(candidate.get("id"))
+            if candidate_id in seen or candidate is doc:
+                continue
+            if candidate.get("category") == category or tags.intersection(set(candidate.get("tags", []))):
+                related_docs.append(candidate)
+                seen.add(candidate_id)
+            if len(related_docs) >= limit:
+                break
+
+        return related_docs[:limit]
+
+    def context(self, query: str, agent: str, limit: int) -> dict[str, Any]:
+        ranked = self.search(f"{query} {agent}", limit=limit)
+        required = [
+            doc for doc in self.documents
+            if doc.get("path") in {"MASTER_CONTEXT.md", "SYSTEM_PROMPT.md"}
+            or doc.get("category") == "constitution"
+            or agent.lower() in str(doc.get("path", "")).lower()
+            or agent.lower() in str(doc.get("id", "")).lower()
+        ]
+
+        selected: list[dict[str, Any]] = []
+        seen: set[str] = set()
+        for doc in required + ranked:
+            doc_id = str(doc.get("id") or doc.get("path"))
+            if doc_id not in seen:
+                selected.append(doc)
+                seen.add(doc_id)
+            if len(selected) >= limit:
+                break
+
+        return {
+            "request_id": "dkos_runtime_context",
+            "query": query,
+            "agent": agent,
+            "documents": selected,
+        }
+
+
+@lru_cache(maxsize=1)
+def get_store() -> KnowledgeStore:
+    artifact_dir = Path(os.getenv("DKOS_ARTIFACT_DIR", ".dkos/artifacts")).resolve()
+    return KnowledgeStore(artifact_dir)
+
+
+def store_or_503() -> KnowledgeStore:
+    try:
+        return get_store()
+    except FileNotFoundError as exc:
+        raise HTTPException(
+            status_code=503,
+            detail={
+                "status": "not_configured",
+                "message": str(exc),
+                "hint": "Generate DKOS artifacts and set DKOS_ARTIFACT_DIR to their directory.",
+            },
+        ) from exc
+
+
+@router.get("/status")
+async def knowledge_status() -> dict[str, Any]:
+    return store_or_503().status()
+
+
+@router.get("/search")
+async def knowledge_search(q: str = Query(..., min_length=1), limit: int = Query(10, ge=1, le=50)) -> dict[str, Any]:
+    return {"query": q, "results": store_or_503().search(q, limit=limit)}
+
+
+@router.get("/entity/{identifier:path}")
+async def knowledge_entity(identifier: str) -> dict[str, Any]:
+    entity = store_or_503().entity(identifier)
+    if not entity:
+        raise HTTPException(status_code=404, detail="Knowledge entity not found")
+    return entity
+
+
+@router.get("/related/{identifier:path}")
+async def knowledge_related(identifier: str, limit: int = Query(20, ge=1, le=100)) -> dict[str, Any]:
+    return {"identifier": identifier, "results": store_or_503().related(identifier, limit=limit)}
+
+
+@router.get("/graph")
+async def knowledge_graph() -> dict[str, Any]:
+    return store_or_503().graph_payload
+
+
+@router.post("/context")
+async def knowledge_context(request: ContextRequest) -> dict[str, Any]:
+    return store_or_503().context(request.query, request.agent, request.limit)

--- a/backend/main.py
+++ b/backend/main.py
@@ -247,6 +247,14 @@ try:
 except ImportError as _hermes_tasks_err:
     logger.warning("backend.hermes.router not found — skipping Hermes task engine. (%s)", _hermes_tasks_err)
 
+try:
+    from backend.knowledge.router import router as knowledge_router  # type: ignore
+
+    app.include_router(knowledge_router)
+    logger.info("DKOS Knowledge API router registered at /api/knowledge/*")
+except ImportError as _knowledge_err:
+    logger.warning("backend.knowledge.router not found — skipping DKOS Knowledge API. (%s)", _knowledge_err)
+
 # ---------------------------------------------------------------------------
 # Health & readiness endpoints
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_knowledge_router.py
+++ b/backend/tests/test_knowledge_router.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from backend.knowledge.router import get_store, router
+
+
+def make_client() -> TestClient:
+    app = FastAPI()
+    app.include_router(router)
+    return TestClient(app)
+
+
+def write_artifacts(root: Path) -> None:
+    index = {
+        "documents": [
+            {"id": "MASTER_CONTEXT", "path": "MASTER_CONTEXT.md", "title": "Master Context", "category": "root", "tags": ["bootstrap"], "related": ["AGENT_HERMES"], "summary": "bootstrap context"},
+            {"id": "AGENT_HERMES", "path": "agents/Hermes/README.md", "title": "Hermes", "category": "agent", "tags": ["hermes", "orchestration"], "related": [], "summary": "planner orchestrator workflow"},
+            {"id": "SKILL_INSURANCE", "path": "skills/insurance.md", "title": "Insurance", "category": "skills", "tags": ["insurance", "crm"], "related": [], "summary": "lead intake policy follow up"},
+        ]
+    }
+    graph = {"nodes": [{"id": "MASTER_CONTEXT"}], "edges": [], "stats": {"total_nodes": 1}}
+    (root / "dkos_index.json").write_text(json.dumps(index), encoding="utf-8")
+    (root / "dkos_graph.json").write_text(json.dumps(graph), encoding="utf-8")
+
+
+def test_knowledge_router_reads_artifacts(monkeypatch, tmp_path: Path):
+    write_artifacts(tmp_path)
+    monkeypatch.setenv("DKOS_ARTIFACT_DIR", str(tmp_path))
+    get_store.cache_clear()
+    client = make_client()
+
+    assert client.get("/api/knowledge/status").json()["documents"] == 3
+    assert client.get("/api/knowledge/search", params={"q": "insurance crm"}).json()["results"][0]["id"] == "SKILL_INSURANCE"
+    assert client.get("/api/knowledge/entity/MASTER_CONTEXT").json()["path"] == "MASTER_CONTEXT.md"
+    assert any(doc["id"] == "AGENT_HERMES" for doc in client.get("/api/knowledge/related/MASTER_CONTEXT").json()["results"])
+    assert client.get("/api/knowledge/graph").json()["nodes"][0]["id"] == "MASTER_CONTEXT"
+    assert client.post("/api/knowledge/context", json={"query": "Build insurance workflow", "agent": "Hermes", "limit": 5}).json()["documents"]
+
+
+def test_knowledge_router_missing_artifacts_returns_503(monkeypatch, tmp_path: Path):
+    monkeypatch.setenv("DKOS_ARTIFACT_DIR", str(tmp_path / "missing"))
+    get_store.cache_clear()
+    response = make_client().get("/api/knowledge/status")
+    assert response.status_code == 503
+    assert response.json()["detail"]["status"] == "not_configured"


### PR DESCRIPTION
## Summary

Mounts the DKOS Knowledge API into the D3VONN.IO FastAPI backend.

## Added

- `backend/knowledge/router.py`
  - `GET /api/knowledge/status`
  - `GET /api/knowledge/search?q=...`
  - `GET /api/knowledge/entity/{identifier}`
  - `GET /api/knowledge/related/{identifier}`
  - `GET /api/knowledge/graph`
  - `POST /api/knowledge/context`
- `backend/knowledge/__init__.py`
- `backend/tests/test_knowledge_router.py`

## Runtime Configuration

The router reads generated DKOS artifacts from:

```text
DKOS_ARTIFACT_DIR=/path/to/dkos/artifacts
```

Required artifact:

```text
dkos_index.json
```

Optional artifacts:

```text
dkos_graph.json
dkos_observability_report.md
dkos_embedding_manifest.json
```

If artifacts are missing, `/api/knowledge/status` returns `503` with a setup hint instead of crashing the app.

## Why This Matters

This connects DKOS to the D3VONN.IO runtime so Hermes, Studio, and specialist agents can retrieve structured knowledge through API routes instead of parsing Markdown directly.

## Next Step After Merge

Deploy the backend with `DKOS_ARTIFACT_DIR` pointed at generated DKOS artifacts, then test:

```text
GET /api/knowledge/status
GET /api/knowledge/search?q=Hermes
POST /api/knowledge/context
```