### PR TITLE
feat(marketing): add D3VONN Marketing Command Center

### DIFF
--- a/backend/app/routers/__init__.py
+++ b/backend/app/routers/__init__.py
@@ -65,3 +65,11 @@ try:
     logger.info("Proxy vault router registered at /api/proxy/*.")
 except ImportError as exc:
     logger.warning("Proxy vault router not registered: %s", exc)
+
+try:
+    from backend.app.routers.marketing import router as marketing_router
+
+    proxy_router.include_router(marketing_router, tags=["marketing"])
+    logger.info("Marketing router registered at /api/marketing/*.")
+except ImportError as exc:
+    logger.warning("Marketing router not registered: %s", exc)

--- a/backend/app/routers/marketing.py
+++ b/backend/app/routers/marketing.py
@@ -1,0 +1,178 @@
+"""Marketing Command Center API routes.
+
+These routes provide a safe first integration surface for Hermes-backed marketing
+workflows. They intentionally prepare internal results only; external channel
+movement remains a separate human-approved workflow.
+"""
+
+from enum import Enum
+from typing import Any, Literal
+from uuid import uuid4
+
+from fastapi import APIRouter
+from pydantic import BaseModel, Field
+
+router = APIRouter(prefix="/api/marketing", tags=["marketing"])
+
+
+class MarketingChannel(str, Enum):
+    x_twitter = "x-twitter"
+    linkedin = "linkedin"
+    tiktok = "tiktok"
+    threads = "threads"
+    youtube_shorts = "youtube-shorts"
+    instagram = "instagram"
+    email = "email"
+    github = "github"
+
+
+class MarketingGenerateRequest(BaseModel):
+    campaign_name: str = Field(..., min_length=1)
+    audience: str = Field(..., min_length=1)
+    channel: MarketingChannel
+    cta: str = Field(..., min_length=1)
+    product_update: str = Field(..., min_length=1)
+    constraints: list[str] = Field(default_factory=list)
+
+
+class MarketingAsset(BaseModel):
+    id: str
+    campaign_id: str | None = None
+    channel: MarketingChannel
+    label: str
+    subject: str | None = None
+    body: str
+    status: str = "DRAFT"
+
+
+class MarketingReviewResult(BaseModel):
+    decision: Literal["APPROVE", "REVISE", "BLOCK"]
+    score: float | None = None
+    issues: list[str] = Field(default_factory=list)
+    suggested_revision: str | None = None
+    required_sources: list[str] = Field(default_factory=list)
+
+
+class MarketingGenerateResponse(BaseModel):
+    asset: MarketingAsset
+    brand_review: MarketingReviewResult | None = None
+    claim_review: MarketingReviewResult | None = None
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+
+class MarketingAssetInput(BaseModel):
+    body: str = Field(..., min_length=1)
+    channel: MarketingChannel
+
+
+class ApproveRequest(BaseModel):
+    asset_id: str
+
+
+class AnalyzeRequest(BaseModel):
+    campaign_id: str
+
+
+@router.post("/generate", response_model=MarketingGenerateResponse)
+def generate_marketing_asset(payload: MarketingGenerateRequest) -> MarketingGenerateResponse:
+    """Generate a draft marketing asset.
+
+    TODO: Replace deterministic draft with Hermes route `generate_social_post`,
+    `generate_email`, or `generate_launch_campaign` based on channel/context.
+    """
+
+    body = (
+        f"Campaign: {payload.campaign_name}\n\n"
+        f"Audience: {payload.audience}\n\n"
+        f"Update: {payload.product_update}\n\n"
+        f"CTA: {payload.cta}"
+    )
+
+    return MarketingGenerateResponse(
+        asset=MarketingAsset(
+            id=str(uuid4()),
+            channel=payload.channel,
+            label=f"{payload.campaign_name} Draft",
+            body=body,
+            status="DRAFT",
+        ),
+        brand_review=MarketingReviewResult(
+            decision="REVISE",
+            score=7.5,
+            issues=["Hermes generation is not yet wired; this is a deterministic draft stub."],
+            suggested_revision="Connect this endpoint to Hermes marketing-agent for full generation.",
+        ),
+        claim_review=MarketingReviewResult(
+            decision="APPROVE",
+            issues=[],
+        ),
+        metadata={"source": "marketing-router-stub"},
+    )
+
+
+@router.post("/rewrite", response_model=MarketingGenerateResponse)
+def rewrite_marketing_asset(payload: MarketingAssetInput) -> MarketingGenerateResponse:
+    return MarketingGenerateResponse(
+        asset=MarketingAsset(
+            id=str(uuid4()),
+            channel=payload.channel,
+            label="Rewrite Draft",
+            body=payload.body,
+            status="DRAFT",
+        ),
+        brand_review=MarketingReviewResult(
+            decision="REVISE",
+            issues=["Hermes rewrite route is not yet wired."],
+        ),
+    )
+
+
+@router.post("/brand-check", response_model=MarketingReviewResult)
+def brand_check(payload: MarketingAssetInput) -> MarketingReviewResult:
+    issues: list[str] = []
+    if "guaranteed" in payload.body.lower():
+        issues.append("Avoid guaranteed outcome language unless verified.")
+    if "military-grade" in payload.body.lower():
+        issues.append("Avoid military-grade language unless formally documented.")
+
+    return MarketingReviewResult(
+        decision="REVISE" if issues else "APPROVE",
+        score=8.0 if not issues else 6.5,
+        issues=issues,
+    )
+
+
+@router.post("/claim-check", response_model=MarketingReviewResult)
+def claim_check(payload: MarketingAssetInput) -> MarketingReviewResult:
+    sensitive_terms = ["soc 2", "hipaa", "guaranteed", "agi", "revenue", "customers"]
+    issues = [f"Requires verification: {term}" for term in sensitive_terms if term in payload.body.lower()]
+
+    return MarketingReviewResult(
+        decision="REVISE" if issues else "APPROVE",
+        issues=issues,
+        required_sources=["marketing/data/approved-claims.md", "marketing/data/metrics-source-of-truth.md"] if issues else [],
+    )
+
+
+@router.post("/approve")
+def approve_asset(payload: ApproveRequest) -> dict[str, Any]:
+    return {"ok": True, "asset_id": payload.asset_id, "status": "APPROVED"}
+
+
+@router.post("/prepare")
+def prepare_channel_asset(payload: MarketingAssetInput) -> dict[str, Any]:
+    return {
+        "ok": True,
+        "channel": payload.channel,
+        "prepared": payload.body,
+        "requires_human_approval": True,
+    }
+
+
+@router.post("/analyze")
+def analyze_campaign(payload: AnalyzeRequest) -> dict[str, Any]:
+    return {
+        "ok": True,
+        "campaign_id": payload.campaign_id,
+        "summary": "Analytics connector pending. Add channel metrics to marketing_metrics for full analysis.",
+    }

--- a/docs/integrations/MARKETING_COMMAND_CENTER_INTEGRATION.md
+++ b/docs/integrations/MARKETING_COMMAND_CENTER_INTEGRATION.md
@@ -1,0 +1,81 @@
+# D3VONN Marketing Command Center Integration Guide
+
+## What This PR Adds
+
+- `/marketing` React route
+- Navigation item for Marketing
+- Reusable `MarketingCommandCenter` component
+- Marketing API client
+- Marketing domain types
+- Supabase schema for campaigns, assets, reviews, and metrics
+- FastAPI router stubs for Hermes-facing marketing operations
+- Marketing knowledge base and agent operating docs
+
+## Frontend Route
+
+The command center is available at:
+
+```txt
+/marketing
+```
+
+## Backend Router Wiring
+
+The router stub lives at:
+
+```txt
+backend/app/routers/marketing.py
+```
+
+To activate it, include it in the backend app registration layer where other routers are mounted:
+
+```python
+from backend.app.routers import marketing
+
+app.include_router(marketing.router)
+```
+
+## Hermes Wiring Targets
+
+Recommended Hermes routes:
+
+```txt
+generate_social_post
+generate_email
+generate_launch_campaign
+brand_check
+claim_check
+prepare_channel_asset
+analyze_campaign
+```
+
+## Database Tables
+
+Migration:
+
+```txt
+supabase/migrations/20260626000001_marketing_command_center.sql
+```
+
+Tables:
+
+- `marketing_campaigns`
+- `marketing_assets`
+- `marketing_reviews`
+- `marketing_metrics`
+
+## Security Model
+
+- Row-level security is enabled.
+- Campaigns/assets are owner-scoped to `auth.uid()`.
+- Public channel movement remains human-approved.
+- Claim-sensitive content must pass claim review.
+
+## Next Implementation Steps
+
+1. Register `backend/app/routers/marketing.py` in the active FastAPI app.
+2. Replace deterministic endpoint stubs with Hermes agent calls.
+3. Move hardcoded UI content into Supabase-backed campaign records.
+4. Add admin/role gating if this route should be private.
+5. Add real analytics ingestion into `marketing_metrics`.
+6. Add optional scheduling adapters after approval workflow is stable.

--- a/docs/integrations/MARKETING_COMMAND_CENTER_INTEGRATION.md
+++ b/docs/integrations/MARKETING_COMMAND_CENTER_INTEGRATION.md
@@ -9,6 +9,7 @@
 - Marketing domain types
 - Supabase schema for campaigns, assets, reviews, and metrics
 - FastAPI router stubs for Hermes-facing marketing operations
+- Backend router registration under `/api/marketing/*`
 - Marketing knowledge base and agent operating docs
 
 ## Frontend Route
@@ -19,6 +20,8 @@ The command center is available at:
 /marketing
 ```
 
+The route is lazy-loaded through `src/App.tsx` and linked from `src/components/navigation/navigationItems.ts`.
+
 ## Backend Router Wiring
 
 The router stub lives at:
@@ -27,12 +30,22 @@ The router stub lives at:
 backend/app/routers/marketing.py
 ```
 
-To activate it, include it in the backend app registration layer where other routers are mounted:
+It is registered defensively in:
 
-```python
-from backend.app.routers import marketing
+```txt
+backend/app/routers/__init__.py
+```
 
-app.include_router(marketing.router)
+Mounted endpoints:
+
+```txt
+POST /api/marketing/generate
+POST /api/marketing/rewrite
+POST /api/marketing/brand-check
+POST /api/marketing/claim-check
+POST /api/marketing/approve
+POST /api/marketing/prepare
+POST /api/marketing/analyze
 ```
 
 ## Hermes Wiring Targets
@@ -70,12 +83,12 @@ Tables:
 - Campaigns/assets are owner-scoped to `auth.uid()`.
 - Public channel movement remains human-approved.
 - Claim-sensitive content must pass claim review.
+- External posting/sending is intentionally not implemented in this PR.
 
 ## Next Implementation Steps
 
-1. Register `backend/app/routers/marketing.py` in the active FastAPI app.
-2. Replace deterministic endpoint stubs with Hermes agent calls.
-3. Move hardcoded UI content into Supabase-backed campaign records.
-4. Add admin/role gating if this route should be private.
-5. Add real analytics ingestion into `marketing_metrics`.
-6. Add optional scheduling adapters after approval workflow is stable.
+1. Replace deterministic endpoint stubs with Hermes agent calls.
+2. Move hardcoded UI content into Supabase-backed campaign records.
+3. Add admin/role gating if this route should be private.
+4. Add real analytics ingestion into `marketing_metrics`.
+5. Add optional scheduling adapters after approval workflow is stable.

--- a/marketing/BRAND_GUIDE.md
+++ b/marketing/BRAND_GUIDE.md
@@ -1,0 +1,51 @@
+# D3VONN Brand Guide
+
+## Brand Essence
+
+D3VONN.IO presents DEVONN.AI as a premium, founder-led AI infrastructure system built for control, auditability, and multi-agent execution.
+
+## Tone
+
+- Clear over clever
+- Proof over hype
+- Operator-focused over theory-heavy
+- Premium command-center language over neon-hacker language
+- Confident but not exaggerated
+
+## Visual Direction
+
+- Dark command-center base
+- Silver-blue/cyan accent
+- Metallic, technical, high-trust feel
+- Avoid neon green as the primary brand signal
+- Avoid cartoonish or meme-only presentation for core assets
+
+## Approved Brand Language
+
+- Sovereign AI infrastructure
+- Autonomous AI infrastructure
+- Multi-agent orchestration
+- Audit-first execution
+- Policy-governed automation
+- Human-in-the-loop approval
+- Self-healing infrastructure patterns
+- Infrastructure ownership
+
+## Avoid
+
+- Guaranteed recovery
+- Unbreakable infrastructure
+- AGI claims
+- Replaces all workers
+- Military-grade security unless certified
+- Compliance claims without supporting documentation
+
+## CTA Style
+
+Use direct action CTAs:
+
+- See it at d3vonn.io
+- Join private beta
+- Request a walkthrough
+- Explore the command center
+- Build with infrastructure you control

--- a/marketing/CONTENT_WORKFLOW.md
+++ b/marketing/CONTENT_WORKFLOW.md
@@ -1,0 +1,39 @@
+# Content Workflow
+
+## Status Flow
+
+```txt
+IDEA
+  -> DRAFT
+  -> BRAND_REVIEW
+  -> CLAIM_CHECK
+  -> APPROVED
+  -> QUEUED
+  -> LIVE
+  -> MEASURED
+  -> REPURPOSED
+```
+
+## Rules
+
+- Drafts can be experimental.
+- Approved content must match brand voice.
+- Public-facing content must avoid unverified claims.
+- Exact metrics must be checked before release.
+- Channel actions require human approval.
+- Results should be reviewed after each campaign.
+- Top-performing content should be repurposed.
+
+## Review Gates
+
+### Brand Review
+
+Checks tone, clarity, audience fit, CTA strength, and D3VONN positioning.
+
+### Claim Check
+
+Checks metrics, compliance language, customer claims, security claims, and anything that could be misleading.
+
+### Human Approval
+
+Required before content is moved from internal approved state to any external channel queue.

--- a/marketing/HERMES_INTEGRATION.md
+++ b/marketing/HERMES_INTEGRATION.md
@@ -1,0 +1,45 @@
+# Hermes Integration Plan
+
+## Purpose
+
+Connect the D3VONN Marketing Command Center to Hermes so marketing work can move through governed agent handoffs.
+
+## Proposed API Routes
+
+```txt
+POST /api/marketing/generate
+POST /api/marketing/rewrite
+POST /api/marketing/brand-check
+POST /api/marketing/claim-check
+POST /api/marketing/approve
+POST /api/marketing/prepare
+POST /api/marketing/analyze
+```
+
+## Approval Rules
+
+- Public channel preparation requires human approval.
+- Claim-sensitive content requires compliance review.
+- Exact metrics must be pulled from source-of-truth files or verified live sources.
+- Sensitive actions should be routed through the existing Hermes approval pattern.
+
+## Agent Handoff
+
+```txt
+Request
+  -> Marketing Agent
+  -> Brand Agent
+  -> Compliance Agent
+  -> Human Approval
+  -> Publisher Agent
+  -> Analytics Agent
+```
+
+## Future Data Sources
+
+- GitHub Actions
+- Repository metadata
+- Website analytics
+- CRM/waitlist data
+- Social engagement metrics
+- Campaign registry

--- a/marketing/IMPLEMENTATION_STATUS.md
+++ b/marketing/IMPLEMENTATION_STATUS.md
@@ -1,0 +1,40 @@
+# Marketing Command Center Implementation Status
+
+## Completed In This Branch
+
+- [x] Marketing knowledge base
+- [x] Agent role documents
+- [x] Brand guide
+- [x] Claim governance files
+- [x] Audience personas
+- [x] Proof-point registry
+- [x] Metrics source-of-truth
+- [x] Content registry seed
+- [x] Prompt pack
+- [x] Private beta launch brief
+- [x] Social and email templates
+- [x] Reusable React component
+- [x] `/marketing` page wrapper
+- [x] App route registration
+- [x] Navbar entry
+- [x] Frontend marketing API client
+- [x] Frontend marketing domain types
+- [x] Supabase schema for campaigns/assets/reviews/metrics
+- [x] FastAPI marketing router stubs
+- [x] Integration guide
+
+## Pending After Merge
+
+- [ ] Register FastAPI marketing router in active backend app
+- [ ] Replace deterministic API stubs with Hermes calls
+- [ ] Persist UI content to Supabase
+- [ ] Add admin or role gating if the route should not be public
+- [ ] Add analytics ingestion adapters
+- [ ] Add scheduling/publishing adapters after approval workflow is stable
+- [ ] Add tests for marketing router and API client
+
+## Risk Notes
+
+The route is wired into the frontend, but the backend router is intentionally not auto-mounted until the active backend registration path is confirmed.
+
+The public-facing Marketing page currently displays reusable promotional content and copy tools. Publishing/scheduling automation is not enabled.

--- a/marketing/LAUNCH_CHECKLIST.md
+++ b/marketing/LAUNCH_CHECKLIST.md
@@ -1,0 +1,38 @@
+# D3VONN Marketing Launch Checklist
+
+## Foundation
+
+- [ ] Create marketing knowledge base
+- [ ] Add approved claims
+- [ ] Add prohibited claims
+- [ ] Add audience personas
+- [ ] Add proof points
+- [ ] Add marketing prompts
+- [ ] Add agent role documents
+
+## Campaign Setup
+
+- [ ] Define campaign name
+- [ ] Define audience
+- [ ] Define CTA
+- [ ] Draft social assets
+- [ ] Draft email assets
+- [ ] Draft GitHub/release assets
+- [ ] Run brand review
+- [ ] Run claim review
+- [ ] Get human approval
+
+## Launch
+
+- [ ] Prepare channel-ready copy
+- [ ] Save approved campaign version
+- [ ] Track campaign date
+- [ ] Track response metrics
+- [ ] Capture top-performing content
+- [ ] Repurpose winners
+
+## Private Beta Campaign
+
+Primary CTA: d3vonn.io
+
+Primary message: Sovereign AI infrastructure for builders who want control, auditability, and multi-agent orchestration.

--- a/marketing/MARKETING_SYSTEM_PROMPT.md
+++ b/marketing/MARKETING_SYSTEM_PROMPT.md
@@ -1,0 +1,63 @@
+# D3VONN Marketing Agent System Prompt
+
+You are the D3VONN Marketing Agent.
+
+Your job is to create clear, premium, trustworthy marketing content for DEVONN.AI and D3VONN.IO.
+
+## Brand Position
+
+DEVONN.AI is an autonomous AI infrastructure platform for multi-agent orchestration, workflow automation, compliance-aware execution, auditability, and self-healing deployment patterns.
+
+## Voice
+
+Use language that feels:
+
+- Premium
+- Technical but readable
+- Founder-led
+- Operator-focused
+- Clear
+- Confident
+- Verifiable
+
+Avoid:
+
+- Hype without proof
+- Fake scarcity
+- Overclaiming
+- Buzzword stacking
+- Neon-hacker language
+- Claims that cannot be verified
+
+## Core Phrases
+
+Approved:
+
+- Sovereign AI infrastructure
+- Multi-agent orchestration
+- Audit-first agent execution
+- Self-healing infrastructure patterns
+- Operator-side AI infrastructure
+- Human-in-the-loop approval
+- Policy-governed automation
+- Infrastructure you can control
+
+Avoid:
+
+- Fully autonomous company unless proven
+- Replaces all employees
+- Guaranteed recovery
+- AGI
+- Unbreakable
+- Military-grade unless legally verified
+
+## Claim Rule
+
+Before publishing exact numbers, check the approved claims file and metrics source of truth.
+
+Use flexible public language when metrics may change:
+
+- 500+ tests
+- Active production deployment
+- Private beta access opening
+- Multi-service orchestration

--- a/marketing/README.md
+++ b/marketing/README.md
@@ -1,0 +1,37 @@
+# D3VONN Marketing Command Center
+
+The D3VONN Marketing Command Center is the marketing operations layer for DEVONN.AI and D3VONN.IO.
+
+It stores approved messaging, campaign assets, launch copy, social posts, email templates, GitHub release language, and agent instructions for producing brand-safe public content.
+
+## Core Purpose
+
+Turn D3VONN.IO from a product into a visible, repeatable, trusted market presence.
+
+## Agent Stack
+
+- Marketing Agent — creates campaign copy
+- Brand Agent — enforces tone, terminology, and positioning
+- Launch Agent — coordinates releases and announcements
+- Analytics Agent — studies performance and recommends next moves
+- Publisher Agent — prepares posts for channels
+- Research Agent — watches competitors, trends, and market opportunities
+- Compliance Agent — checks public claims before publishing
+
+## Golden Rule
+
+No public claim ships unless it is verified in `data/approved-claims.md`, sourced from `data/metrics-source-of-truth.md`, or clearly marked as general positioning.
+
+## Operating Loop
+
+```txt
+Marketing Command Center
+  -> Marketing Knowledge Base
+  -> Agent Drafting
+  -> Brand Review
+  -> Claim Review
+  -> Human Approval
+  -> Publishing Queue
+  -> Analytics Feedback
+  -> Reusable Winning Content
+```

--- a/marketing/ROUTING_MAP.md
+++ b/marketing/ROUTING_MAP.md
@@ -1,0 +1,48 @@
+# Marketing Routing Map
+
+## Routes
+
+```yaml
+generate_social_post:
+  owner: marketing-agent
+  reviewers:
+    - brand-agent
+    - compliance-agent
+
+generate_email:
+  owner: marketing-agent
+  reviewers:
+    - brand-agent
+    - compliance-agent
+
+generate_launch_campaign:
+  owner: launch-agent
+  reviewers:
+    - marketing-agent
+    - brand-agent
+    - compliance-agent
+
+prepare_channel_asset:
+  owner: publisher-agent
+  requires_human_approval: true
+
+analyze_campaign:
+  owner: analytics-agent
+  reviewers:
+    - marketing-agent
+
+research_trends:
+  owner: research-agent
+  reviewers:
+    - marketing-agent
+```
+
+## Route Philosophy
+
+- Marketing Agent drafts.
+- Brand Agent improves fit and voice.
+- Compliance Agent checks claims.
+- Launch Agent packages multi-channel campaigns.
+- Publisher Agent prepares channel-ready output.
+- Analytics Agent creates feedback loops.
+- Research Agent feeds timely opportunities back into the system.

--- a/marketing/agents/analytics-agent.md
+++ b/marketing/agents/analytics-agent.md
@@ -1,0 +1,29 @@
+# Analytics Agent
+
+## Mission
+
+Measure marketing performance and turn campaign results into better future content.
+
+## Inputs
+
+- Campaign registry
+- Channel metrics
+- Engagement notes
+- Conversion signals
+- Qualitative feedback
+
+## Outputs
+
+- Campaign recap
+- Winning content list
+- Repurpose recommendations
+- Audience insight notes
+- Next campaign recommendations
+
+## Questions To Answer
+
+- Which message performed best?
+- Which audience responded?
+- Which CTA created the most action?
+- Which posts should be repurposed?
+- What should the next campaign test?

--- a/marketing/agents/brand-agent.md
+++ b/marketing/agents/brand-agent.md
@@ -1,0 +1,22 @@
+# Brand Agent
+
+## Mission
+
+Protect D3VONN brand consistency.
+
+## Checks
+
+- Is the tone premium?
+- Is the claim verifiable?
+- Is the wording clear?
+- Does it avoid hype?
+- Does it match D3VONN positioning?
+- Does it sound founder-led and operator-focused?
+
+## Rewrite Rules
+
+- Replace hype with proof.
+- Replace vague claims with specific architecture.
+- Replace weak CTA with action-oriented CTA.
+- Replace neon/hacker language with silver-blue command-center language.
+- Preserve clarity and trust over aggressive persuasion.

--- a/marketing/agents/compliance-agent.md
+++ b/marketing/agents/compliance-agent.md
@@ -1,0 +1,23 @@
+# Compliance Agent
+
+## Mission
+
+Prevent unverified, misleading, or risky public claims from leaving the marketing workflow.
+
+## Checks
+
+- Exact numbers are verified before use.
+- Security claims are supported by documentation.
+- Compliance claims are not implied without proof.
+- Customer or revenue claims are not used without approval.
+- Regulated-industry language remains careful and accurate.
+
+## Decision Labels
+
+- APPROVE — safe to proceed.
+- REVISE — needs clearer wording or source.
+- BLOCK — claim should not be used publicly.
+
+## Default Rule
+
+When uncertain, replace exact or sensitive claims with flexible, verifiable positioning language.

--- a/marketing/agents/launch-agent.md
+++ b/marketing/agents/launch-agent.md
@@ -1,0 +1,26 @@
+# Launch Agent
+
+## Mission
+
+Coordinate launch campaigns for DEVONN.AI releases, private beta updates, product milestones, and major feature announcements.
+
+## Responsibilities
+
+- Package launch assets across channels
+- Maintain launch checklists
+- Coordinate review gates
+- Produce release notes and campaign briefs
+- Prepare post-launch recap inputs
+
+## Output Bundle
+
+A complete launch bundle should include:
+
+- Launch brief
+- X/Twitter posts
+- LinkedIn post
+- Short-form video script
+- Email copy
+- GitHub release copy
+- Website hero or landing copy
+- Claim-check notes

--- a/marketing/agents/marketing-agent.md
+++ b/marketing/agents/marketing-agent.md
@@ -1,0 +1,33 @@
+# Marketing Agent
+
+## Mission
+
+Create high-quality marketing assets for DEVONN.AI across social, email, GitHub, launch, and website channels.
+
+## Inputs
+
+- Product updates
+- Approved claims
+- Brand guide
+- Target audience
+- Channel
+- CTA
+
+## Outputs
+
+- Social posts
+- Email drafts
+- Launch announcements
+- Website copy
+- GitHub release copy
+- Short-form video scripts
+
+## Workflow
+
+1. Read approved claims.
+2. Identify audience.
+3. Choose channel format.
+4. Draft content.
+5. Pass to Brand Agent.
+6. Pass to Claim Check.
+7. Prepare for approval.

--- a/marketing/agents/publisher-agent.md
+++ b/marketing/agents/publisher-agent.md
@@ -1,0 +1,25 @@
+# Publisher Agent
+
+## Mission
+
+Prepare approved marketing content for the correct channel format.
+
+## Responsibilities
+
+- Format content for each channel
+- Check character or layout constraints
+- Attach CTA
+- Preserve approved claims
+- Keep a clear approval trail
+
+## Approval Rule
+
+The Publisher Agent prepares channel-ready assets. Final external channel movement remains human-approved.
+
+## Outputs
+
+- Channel-ready post
+- Channel-ready email
+- Markdown export
+- Plain text export
+- Campaign registry update

--- a/marketing/agents/research-agent.md
+++ b/marketing/agents/research-agent.md
@@ -1,0 +1,25 @@
+# Research Agent
+
+## Mission
+
+Find timely market opportunities, competitor signals, audience questions, and content angles that support DEVONN.AI growth.
+
+## Inputs
+
+- Market trends
+- Competitor positioning
+- Search demand
+- Community questions
+- Product updates
+
+## Outputs
+
+- Content opportunity briefs
+- Trend summaries
+- Competitor positioning notes
+- Campaign angle recommendations
+- Keyword and topic ideas
+
+## Review Rule
+
+Research outputs are inputs, not public claims. Any public-facing use must pass brand and claim review.

--- a/marketing/data/approved-claims.md
+++ b/marketing/data/approved-claims.md
@@ -1,0 +1,36 @@
+# Approved Claims
+
+Last reviewed: 2026-06-26
+
+## Safe Public Claims
+
+- DEVONN.AI is a multi-agent AI infrastructure platform.
+- D3VONN.IO is the public web property.
+- Hermes is the orchestration layer.
+- The stack uses FastAPI, Railway, Vercel, Supabase, and Pinecone.
+- The system includes human-in-the-loop approval patterns.
+- The system includes audit-first agent execution patterns.
+- The system includes policy-governed automation.
+- The system is designed for self-healing infrastructure patterns.
+
+## Flexible Claims
+
+Use these publicly unless exact live metrics are verified:
+
+- 500+ tests
+- Production deployment active
+- Private beta access opening
+- Multi-service orchestration
+- Founder-built infrastructure
+
+## Claims Requiring Verification Before Publishing
+
+- Exact test count
+- Exact CI check count
+- Exact commit count
+- Exact number of repos/services
+- RC version number
+- Revenue numbers
+- Customer numbers
+- Security certifications
+- Compliance certifications

--- a/marketing/data/audience-personas.md
+++ b/marketing/data/audience-personas.md
@@ -1,0 +1,31 @@
+# Audience Personas
+
+## Solo AI Founder
+
+Needs speed, automation, deployment confidence, and leverage.
+
+Messaging angle: one founder can operate with a serious infrastructure layer.
+
+## Technical Operator
+
+Needs observability, auditability, reliability, and control.
+
+Messaging angle: agents should be visible, governed, and recoverable.
+
+## Regulated Industry Builder
+
+Needs compliance-aware automation, approval gates, and traceability.
+
+Messaging angle: policy-governed workflows and human-in-the-loop approval matter.
+
+## Investor / Partner
+
+Needs clear positioning, proof, traction, and market vision.
+
+Messaging angle: D3VONN.IO is building toward a full AI operating system, not a single feature.
+
+## Beta User
+
+Needs simple onboarding, clear value, and trustworthy product messaging.
+
+Messaging angle: private beta gives early access to infrastructure patterns that normally require a full engineering team.

--- a/marketing/data/content-registry.json
+++ b/marketing/data/content-registry.json
@@ -1,0 +1,25 @@
+{
+  "version": "1.0.0",
+  "updated": "2026-06-26",
+  "campaigns": [
+    {
+      "id": "private-beta-launch",
+      "name": "DEVONN.AI Private Beta",
+      "status": "draft",
+      "primary_cta": "https://d3vonn.io",
+      "primary_message": "Sovereign AI infrastructure for builders who want control, auditability, and multi-agent orchestration.",
+      "channels": ["x-twitter", "linkedin", "tiktok", "email", "github"]
+    }
+  ],
+  "statuses": [
+    "IDEA",
+    "DRAFT",
+    "BRAND_REVIEW",
+    "CLAIM_CHECK",
+    "APPROVED",
+    "QUEUED",
+    "LIVE",
+    "MEASURED",
+    "REPURPOSED"
+  ]
+}

--- a/marketing/data/metrics-source-of-truth.md
+++ b/marketing/data/metrics-source-of-truth.md
@@ -1,0 +1,24 @@
+# Metrics Source of Truth
+
+Use this file to record where public metrics should be verified before publication.
+
+## Metrics That Require Verification
+
+| Metric | Source | Notes |
+|---|---|---|
+| Test count | GitHub Actions / test reports | Use exact count only when current |
+| CI checks | GitHub Actions | Avoid exact counts unless verified |
+| Commit count | Git history | Use flexible language if uncertain |
+| Version number | VERSION / release tags | Confirm before release content |
+| Deployment status | Vercel / Railway dashboards | Confirm live status before public claim |
+| Security/compliance status | Formal documentation | Do not infer certification |
+
+## Public-Safe Defaults
+
+When exact metrics are not verified, use:
+
+- 500+ tests
+- Active production deployment
+- Multi-service orchestration
+- Private beta access opening
+- Founder-built infrastructure

--- a/marketing/data/prohibited-claims.md
+++ b/marketing/data/prohibited-claims.md
@@ -1,0 +1,27 @@
+# Prohibited Claims
+
+Do not claim publicly unless a current, authoritative source is attached:
+
+- Guaranteed uptime
+- Guaranteed recovery
+- AGI
+- Fully autonomous company
+- Replaces all employees
+- Military-grade security
+- HIPAA compliance
+- SOC 2 compliance
+- Enterprise customers
+- Revenue numbers
+- Exact test, CI, or commit counts
+- Legal, insurance, or financial compliance status
+- Any customer relationship that has not been approved for public reference
+
+## Replacement Pattern
+
+Instead of overclaiming, use verified operator language.
+
+Examples:
+
+- Replace "guaranteed recovery" with "self-healing infrastructure patterns."
+- Replace "fully autonomous company" with "multi-agent orchestration system."
+- Replace "military-grade security" with "policy-governed execution and audit-first design."

--- a/marketing/data/proof-points.md
+++ b/marketing/data/proof-points.md
@@ -1,0 +1,37 @@
+# Proof Points
+
+Use these proof points when drafting public messaging.
+
+## Infrastructure
+
+- FastAPI backend
+- Vercel frontend
+- Railway backend deployment
+- Supabase database foundation
+- Pinecone RAG foundation
+- Hermes orchestration layer
+
+## Governance
+
+- Human-in-the-loop approval patterns
+- Policy-governed automation
+- Audit-first agent execution language
+- Claims reviewed before public release
+
+## Positioning
+
+- Founder-built infrastructure
+- Operator-side design
+- Sovereign AI infrastructure
+- Multi-agent orchestration
+- Self-healing infrastructure patterns
+
+## CTA
+
+Primary: d3vonn.io
+
+Secondary:
+
+- Request a walkthrough
+- Join private beta
+- Explore the command center

--- a/marketing/email/beta-invite.md
+++ b/marketing/email/beta-invite.md
@@ -1,0 +1,27 @@
+# Beta Invite Email
+
+## Subject
+
+DEVONN.AI Private Beta — Access is opening
+
+## Body
+
+You asked to hear when DEVONN.AI opened beta access. That time is now.
+
+Here's what you're getting access to:
+
+- Hermes multi-agent orchestration
+- Unified API gateway for AI services
+- Supabase + Pinecone RAG foundation
+- Policy engine with compliance enforcement
+- Voice-agent compliance gating
+- Self-healing infrastructure patterns
+- Audit-first agent execution
+
+This is infrastructure built from the operator side — designed for real deployment, recovery, auditability, and control.
+
+Get started: d3vonn.io
+
+Questions? Reply here.
+
+— Wesley

--- a/marketing/launch/private-beta-launch.md
+++ b/marketing/launch/private-beta-launch.md
@@ -1,0 +1,42 @@
+# DEVONN.AI Private Beta Launch
+
+## Campaign
+
+DEVONN.AI Private Beta
+
+## Primary CTA
+
+https://d3vonn.io
+
+## Primary Message
+
+Sovereign AI infrastructure for builders who want control, auditability, and multi-agent orchestration.
+
+## Audience
+
+- Solo AI founders
+- Technical operators
+- Regulated-industry builders
+- Early beta users
+- Investors and partners
+
+## Core Assets
+
+- X/Twitter posts
+- LinkedIn founder post
+- Short-form video scripts
+- Beta invite email
+- GitHub README promo block
+- Release announcement
+
+## Claim Safety
+
+Use flexible language unless exact metrics are verified.
+
+Approved flexible phrasing:
+
+- 500+ tests
+- Active production deployment
+- Private beta access opening
+- Multi-service orchestration
+- Founder-built infrastructure

--- a/marketing/prompts/brand-check-prompt.md
+++ b/marketing/prompts/brand-check-prompt.md
@@ -1,0 +1,21 @@
+# Brand Check Prompt
+
+Review this D3VONN.IO content for brand fit.
+
+## Check For
+
+- Premium tone
+- Clear positioning
+- Operator-focused language
+- Strong but truthful CTA
+- No unverified hype
+- No neon-hacker wording
+
+## Output
+
+Return:
+
+- Brand score out of 10
+- Issues found
+- Improved version
+- Final approval status

--- a/marketing/prompts/claim-check-prompt.md
+++ b/marketing/prompts/claim-check-prompt.md
@@ -1,0 +1,23 @@
+# Claim Check Prompt
+
+Review this D3VONN.IO content for claim safety.
+
+## Check Against
+
+- `marketing/data/approved-claims.md`
+- `marketing/data/prohibited-claims.md`
+- `marketing/data/metrics-source-of-truth.md`
+
+## Output
+
+Return:
+
+- APPROVE, REVISE, or BLOCK
+- Claims found
+- Risk level
+- Suggested safer wording
+- Required verification sources
+
+## Default Rule
+
+If a claim is exact, sensitive, or compliance-related and no source is available, mark it REVISE or BLOCK.

--- a/marketing/prompts/generate-campaign.md
+++ b/marketing/prompts/generate-campaign.md
@@ -1,0 +1,29 @@
+# Generate Campaign Prompt
+
+Create a multi-channel D3VONN.IO campaign.
+
+## Inputs
+
+- Campaign name
+- Audience
+- Primary CTA
+- Product update
+- Approved claims
+- Channels
+
+## Required Output
+
+- Campaign brief
+- X/Twitter posts
+- LinkedIn post
+- Short-form video scripts
+- Email draft
+- GitHub/release copy
+- Claim-check notes
+
+## Rules
+
+- Use approved claims only.
+- Avoid hype without proof.
+- Keep language premium, founder-led, and operator-focused.
+- Include a clear CTA.

--- a/marketing/prompts/platform-optimize-prompt.md
+++ b/marketing/prompts/platform-optimize-prompt.md
@@ -1,0 +1,27 @@
+# Platform Optimize Prompt
+
+Optimize this D3VONN.IO content for a specific platform.
+
+## Inputs
+
+- Draft content
+- Target platform
+- Audience
+- CTA
+
+## Platform Notes
+
+- X/Twitter: sharp hook, compact proof, direct CTA
+- LinkedIn: narrative, operating lesson, architecture proof
+- TikTok/Reels/Shorts: visual hook, quick sequence, caption
+- Email: personal, clear value, one CTA
+- GitHub: concise, technical, markdown-friendly
+
+## Output
+
+Return:
+
+- Optimized version
+- Why it changed
+- Character count or format notes
+- CTA check

--- a/marketing/social/linkedin.md
+++ b/marketing/social/linkedin.md
@@ -1,0 +1,23 @@
+# LinkedIn Promo Template
+
+## Founder Post
+
+When people ask how I run an AI platform solo, I show them the mesh.
+
+DEVONN.AI is a multi-agent autonomous infrastructure system built for deployment, auditability, and control.
+
+Here's what's under the hood:
+
+- Hermes orchestrator with human-in-the-loop approval for sensitive actions
+- FastAPI gateway proxying AI services behind authenticated routes
+- Supabase + Pinecone RAG pipeline
+- Policy engine enforcing DENY > REQUIRE_APPROVAL > ALLOW
+- Immutable audit trail for agent actions
+- Frontend live on Vercel with backend services on Railway
+- Edge-ready architecture designed for local and cloud execution
+
+This is what infrastructure ownership looks like when you're not waiting on a team, a vendor, or a locked-in platform.
+
+Private beta access is opening for builders, founders, and operators who want autonomous infrastructure they can actually control.
+
+See it at d3vonn.io

--- a/marketing/social/x-twitter.md
+++ b/marketing/social/x-twitter.md
@@ -1,0 +1,40 @@
+# X / Twitter Promo Templates
+
+## Builder Hook
+
+I built a self-healing AI mesh that auto-deploys, auto-recovers, and orchestrates multiple services with one command.
+
+No bloated team. No locked-in platform.
+
+Just sovereign AI infrastructure.
+
+Meet DEVONN.AI 👁️ → d3vonn.io
+
+## Tech Stack Flex
+
+DEVONN.AI stack:
+
+⚡ FastAPI on Railway
+🧠 Hermes orchestrator with HITL approval
+🗄️ Supabase + Pinecone RAG
+🔐 JWT + Zero-Trust HMAC
+📦 500+ tests
+🌐 Vercel frontend live
+
+Built by one founder.
+
+d3vonn.io
+
+## Pain Point
+
+Most AI platforms:
+→ Lock you into their infra
+→ Hide what agents are doing
+→ Break when you need them most
+
+DEVONN.AI:
+→ You control the infrastructure
+→ Every agent action is auditable
+→ The mesh can recover automatically
+
+d3vonn.io

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -81,6 +81,7 @@ const Resources = lazy(() => import("./pages/Resources"));
 const Security = lazy(() => import("./pages/Security"));
 const Pricing = lazy(() => import("./pages/Pricing"));
 const ResearchOS = lazy(() => import("./pages/ResearchOS"));
+const MarketingCommandCenter = lazy(() => import("./pages/MarketingCommandCenter"));
 
 // Wrapper for AdminRoute since lazy components can't directly accept children as JSX
 const AdminRouteWrapper = lazy(() =>
@@ -194,6 +195,7 @@ function App() {
                 <Route path="/security" element={<Security />} />
                 <Route path="/pricing" element={<Pricing />} />
                 <Route path="/research-os" element={<ResearchOS />} />
+                <Route path="/marketing" element={<MarketingCommandCenter />} />
                 <Route path="/platform" element={<Navigate to="/#platform" replace />} />
                 <Route path="/signin" element={<Navigate to="/login" replace />} />
                 <Route path="/signup" element={<Navigate to="/login" replace />} />

--- a/src/api/marketing/index.ts
+++ b/src/api/marketing/index.ts
@@ -1,0 +1,2 @@
+export { marketingApi } from "./marketingApi";
+export type * from "../../types/marketing";

--- a/src/api/marketing/marketingApi.ts
+++ b/src/api/marketing/marketingApi.ts
@@ -1,0 +1,53 @@
+import type {
+  MarketingAsset,
+  MarketingGenerateRequest,
+  MarketingGenerateResponse,
+  MarketingReviewResult,
+} from "../../types/marketing";
+
+async function postJson<TResponse, TPayload>(path: string, payload: TPayload): Promise<TResponse> {
+  const response = await fetch(path, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    credentials: "include",
+    body: JSON.stringify(payload),
+  });
+
+  if (!response.ok) {
+    const message = await response.text().catch(() => "Unknown marketing API error");
+    throw new Error(message || `Marketing API request failed: ${response.status}`);
+  }
+
+  return response.json() as Promise<TResponse>;
+}
+
+export const marketingApi = {
+  generate(payload: MarketingGenerateRequest) {
+    return postJson<MarketingGenerateResponse, MarketingGenerateRequest>("/api/marketing/generate", payload);
+  },
+
+  rewrite(asset: Pick<MarketingAsset, "body" | "channel">) {
+    return postJson<MarketingGenerateResponse, typeof asset>("/api/marketing/rewrite", asset);
+  },
+
+  brandCheck(asset: Pick<MarketingAsset, "body" | "channel">) {
+    return postJson<MarketingReviewResult, typeof asset>("/api/marketing/brand-check", asset);
+  },
+
+  claimCheck(asset: Pick<MarketingAsset, "body" | "channel">) {
+    return postJson<MarketingReviewResult, typeof asset>("/api/marketing/claim-check", asset);
+  },
+
+  approve(assetId: string) {
+    return postJson<{ ok: true; assetId: string }, { assetId: string }>("/api/marketing/approve", { assetId });
+  },
+
+  analyze(campaignId: string) {
+    return postJson<{ ok: true; campaignId: string; summary: string }, { campaignId: string }>(
+      "/api/marketing/analyze",
+      { campaignId }
+    );
+  },
+};

--- a/src/api/marketing/marketingApi.ts
+++ b/src/api/marketing/marketingApi.ts
@@ -5,6 +5,31 @@ import type {
   MarketingReviewResult,
 } from "../../types/marketing";
 
+type ApiGenerateRequest = {
+  campaign_name: string;
+  audience: string;
+  channel: MarketingGenerateRequest["channel"];
+  cta: string;
+  product_update: string;
+  constraints?: string[];
+};
+
+type ApiAssetInput = {
+  body: string;
+  channel: MarketingAsset["channel"];
+};
+
+function toGeneratePayload(payload: MarketingGenerateRequest): ApiGenerateRequest {
+  return {
+    campaign_name: payload.campaignName,
+    audience: payload.audience,
+    channel: payload.channel,
+    cta: payload.cta,
+    product_update: payload.productUpdate,
+    constraints: payload.constraints,
+  };
+}
+
 async function postJson<TResponse, TPayload>(path: string, payload: TPayload): Promise<TResponse> {
   const response = await fetch(path, {
     method: "POST",
@@ -25,29 +50,41 @@ async function postJson<TResponse, TPayload>(path: string, payload: TPayload): P
 
 export const marketingApi = {
   generate(payload: MarketingGenerateRequest) {
-    return postJson<MarketingGenerateResponse, MarketingGenerateRequest>("/api/marketing/generate", payload);
+    return postJson<MarketingGenerateResponse, ApiGenerateRequest>(
+      "/api/marketing/generate",
+      toGeneratePayload(payload)
+    );
   },
 
   rewrite(asset: Pick<MarketingAsset, "body" | "channel">) {
-    return postJson<MarketingGenerateResponse, typeof asset>("/api/marketing/rewrite", asset);
+    return postJson<MarketingGenerateResponse, ApiAssetInput>("/api/marketing/rewrite", asset);
   },
 
   brandCheck(asset: Pick<MarketingAsset, "body" | "channel">) {
-    return postJson<MarketingReviewResult, typeof asset>("/api/marketing/brand-check", asset);
+    return postJson<MarketingReviewResult, ApiAssetInput>("/api/marketing/brand-check", asset);
   },
 
   claimCheck(asset: Pick<MarketingAsset, "body" | "channel">) {
-    return postJson<MarketingReviewResult, typeof asset>("/api/marketing/claim-check", asset);
+    return postJson<MarketingReviewResult, ApiAssetInput>("/api/marketing/claim-check", asset);
   },
 
   approve(assetId: string) {
-    return postJson<{ ok: true; assetId: string }, { assetId: string }>("/api/marketing/approve", { assetId });
+    return postJson<{ ok: true; assetId: string }, { asset_id: string }>("/api/marketing/approve", {
+      asset_id: assetId,
+    });
+  },
+
+  prepare(asset: Pick<MarketingAsset, "body" | "channel">) {
+    return postJson<{ ok: true; channel: string; prepared: string; requires_human_approval: boolean }, ApiAssetInput>(
+      "/api/marketing/prepare",
+      asset
+    );
   },
 
   analyze(campaignId: string) {
-    return postJson<{ ok: true; campaignId: string; summary: string }, { campaignId: string }>(
+    return postJson<{ ok: true; campaign_id: string; summary: string }, { campaign_id: string }>(
       "/api/marketing/analyze",
-      { campaignId }
+      { campaign_id: campaignId }
     );
   },
 };

--- a/src/components/MarketingCommandCenter.d.ts
+++ b/src/components/MarketingCommandCenter.d.ts
@@ -1,0 +1,3 @@
+declare const MarketingCommandCenter: () => JSX.Element;
+
+export default MarketingCommandCenter;

--- a/src/components/MarketingCommandCenter.jsx
+++ b/src/components/MarketingCommandCenter.jsx
@@ -1,0 +1,225 @@
+import { useState } from "react";
+
+const BRAND = {
+  accent: "#7FD7FF",
+  accentSoft: "#7FD7FF22",
+  bg: "#060606",
+  panel: "#0d0d0d",
+  panelSoft: "#0a0a0a",
+  border: "#1e293b",
+  borderSoft: "#1a1a1a",
+  text: "#d4d4d4",
+  muted: "#777",
+  dim: "#ffffff55",
+  warn: "#ffb86b",
+};
+
+const CONTENT = {
+  twitter: [
+    {
+      label: "Builder Hook",
+      text: `I built a self-healing AI mesh that auto-deploys, auto-recovers, and orchestrates multiple services with one command.\n\nNo bloated team. No locked-in platform.\n\nJust sovereign AI infrastructure.\n\nMeet DEVONN.AI 👁️ → d3vonn.io`,
+    },
+    {
+      label: "Tech Stack Flex",
+      text: `DEVONN.AI stack:\n\n⚡ FastAPI on Railway\n🧠 Hermes orchestrator with HITL approval\n🗄️ Supabase + Pinecone RAG\n🔐 JWT + Zero-Trust HMAC\n📦 500+ tests\n🌐 Vercel frontend live\n\nBuilt by one founder.\n\nd3vonn.io`,
+    },
+    {
+      label: "Pain Point",
+      text: `Most AI platforms:\n→ Lock you into their infra\n→ Hide what agents are doing\n→ Break when you need them most\n\nDEVONN.AI:\n→ You control the infrastructure\n→ Every agent action is auditable\n→ The mesh can recover automatically\n\nd3vonn.io`,
+    },
+  ],
+  tiktok: [
+    {
+      label: "Explainer",
+      text: `Hook: "This one command starts my AI company."\n\nShow: bash run_all.sh → Hermes dispatches agents → API gateway routes requests → auto-healer reacts if anything breaks\n\nCaption: Sovereign AI infrastructure at d3vonn.io`,
+    },
+    {
+      label: "Tech Tour",
+      text: `Hook: "Let me show you what a self-healing AI mesh looks like."\n\nShow: GitHub repo tour → backend → frontend → policy engine → live dashboard\n\nCaption: Built different. d3vonn.io`,
+    },
+  ],
+  linkedin: [
+    {
+      label: "Founder Post",
+      text: `When people ask how I run an AI platform solo, I show them the mesh.\n\nDEVONN.AI is a multi-agent autonomous infrastructure system built for deployment, auditability, and control.\n\nHere's what's under the hood:\n\n• Hermes orchestrator with human-in-the-loop approval for sensitive actions\n• FastAPI gateway proxying AI services behind authenticated routes\n• Supabase + Pinecone RAG pipeline\n• Policy engine enforcing DENY > REQUIRE_APPROVAL > ALLOW\n• Immutable audit trail for agent actions\n• Frontend live on Vercel with backend services on Railway\n• Edge-ready architecture designed for local and cloud execution\n\nThis is what infrastructure ownership looks like when you're not waiting on a team, a vendor, or a locked-in platform.\n\nPrivate beta access is opening for builders, founders, and operators who want autonomous infrastructure they can actually control.\n\nSee it at d3vonn.io`,
+    },
+  ],
+  email: [
+    {
+      label: "Cold Outreach — Founders",
+      subject: "Built a self-healing AI mesh — thought you'd want to see it",
+      text: `Hey [Name],\n\nI'm Wesley, founder of DEVONN.AI.\n\nI built a multi-agent autonomous infrastructure system that coordinates AI services through a unified command layer. Hermes, the orchestrator, dispatches agents, routes requests through a FastAPI gateway, and supports recovery workflows with human approval gates for sensitive actions.\n\nDEVONN.AI is built for people who want AI infrastructure they can control, audit, and extend — not another black-box SaaS layer.\n\nPrivate beta access is opening for a small group of builders, founders, and operators.\n\nInterested in a walkthrough?\n\n— Wesley\nd3vonn.io`,
+    },
+  ],
+  github: {
+    label: "GitHub README Badge Block",
+    text: `> **DEVONN.AI** — Autonomous Multi-Agent Infrastructure Platform\n>\n> One command. Multi-service orchestration. Self-healing mesh.\n>\n> 🌐 [d3vonn.io](https://d3vonn.io) · 📦 500+ tests · 🚀 Private Beta\n\n[![Live](https://img.shields.io/badge/status-live-blue)](https://d3vonn.io)\n[![Tests](https://img.shields.io/badge/tests-500%2B-blue)](https://github.com/wesship/supreme-ai-deployment-hub/actions)\n[![Beta](https://img.shields.io/badge/private_beta-opening-silver)](https://d3vonn.io)`,
+  },
+};
+
+const CHANNELS = [
+  { key: "twitter", label: "𝕏 / Twitter" },
+  { key: "tiktok", label: "TikTok" },
+  { key: "linkedin", label: "LinkedIn" },
+  { key: "email", label: "Email" },
+  { key: "github", label: "GitHub" },
+];
+
+function getChannelCopy(active) {
+  const items = CONTENT[active];
+  if (!items) return "";
+  if (active === "github") return items.text;
+
+  return items
+    .map((item) => {
+      const subject = item.subject ? `Subject: ${item.subject}\n\n` : "";
+      return `${item.label}\n\n${subject}${item.text}`;
+    })
+    .join("\n\n---\n\n");
+}
+
+function CopyButton({ text, label = "content" }) {
+  const [copied, setCopied] = useState(false);
+  const [failed, setFailed] = useState(false);
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopied(true);
+      setFailed(false);
+      setTimeout(() => setCopied(false), 1800);
+    } catch {
+      setFailed(true);
+      setTimeout(() => setFailed(false), 2200);
+    }
+  };
+
+  return (
+    <button
+      onClick={handleCopy}
+      aria-label={`Copy ${label}`}
+      style={{
+        background: copied ? BRAND.accentSoft : "#ffffff0f",
+        border: `1px solid ${copied ? BRAND.accent : "#ffffff22"}`,
+        color: copied ? BRAND.accent : failed ? "#ff8a8a" : "#aaa",
+        borderRadius: 6,
+        padding: "6px 14px",
+        fontSize: 12,
+        fontFamily: "'JetBrains Mono', monospace",
+        cursor: "pointer",
+        transition: "all 0.2s",
+        letterSpacing: "0.05em",
+      }}
+    >
+      {copied ? "COPIED ✓" : failed ? "FAILED" : "COPY"}
+    </button>
+  );
+}
+
+function Card({ label, text, subject, active }) {
+  const copyText = subject ? `Subject: ${subject}\n\n${text}` : text;
+  const isTwitter = active === "twitter";
+  const isOverLimit = isTwitter && text.length > 280;
+
+  return (
+    <div
+      style={{
+        background: BRAND.panel,
+        border: `1px solid ${BRAND.border}`,
+        borderRadius: 10,
+        padding: "18px 20px",
+        marginBottom: 14,
+      }}
+    >
+      <div style={{ display: "flex", justifyContent: "space-between", gap: 16, alignItems: "center", marginBottom: 10 }}>
+        <span style={{ fontSize: 11, color: BRAND.accent, letterSpacing: "0.12em", textTransform: "uppercase" }}>{label}</span>
+        <CopyButton text={copyText} label={label} />
+      </div>
+
+      <div style={{ fontSize: 11, color: isOverLimit ? BRAND.warn : BRAND.muted, marginBottom: 10, letterSpacing: "0.04em" }}>
+        {text.length} characters{isOverLimit ? " · over X short-post limit" : ""}
+      </div>
+
+      {subject && (
+        <div style={{ fontSize: 12, color: BRAND.dim, marginBottom: 8, borderBottom: `1px solid ${BRAND.borderSoft}`, paddingBottom: 8 }}>
+          Subject: <span style={{ color: "#ffffff99" }}>{subject}</span>
+        </div>
+      )}
+
+      <pre style={{ margin: 0, whiteSpace: "pre-wrap", fontFamily: "'JetBrains Mono', monospace", fontSize: 13, color: BRAND.text, lineHeight: 1.7, overflowWrap: "break-word" }}>
+        {text}
+      </pre>
+    </div>
+  );
+}
+
+export default function MarketingCommandCenter() {
+  const [active, setActive] = useState("twitter");
+
+  const renderContent = () => {
+    const items = CONTENT[active];
+    if (!items) return null;
+    if (active === "github") return <Card label={items.label} text={items.text} active={active} />;
+    return items.map((item, i) => <Card key={`${active}-${i}`} label={item.label} text={item.text} subject={item.subject} active={active} />);
+  };
+
+  return (
+    <main style={{ minHeight: "100vh", background: BRAND.bg, fontFamily: "'JetBrains Mono', monospace", color: "#fff", padding: "0 0 60px" }}>
+      <div style={{ maxWidth: 980, margin: "0 auto" }}>
+        <header style={{ borderBottom: `1px solid ${BRAND.borderSoft}`, padding: "28px 24px 20px" }}>
+          <div style={{ fontSize: 11, color: BRAND.accent, letterSpacing: "0.2em", marginBottom: 6, textTransform: "uppercase" }}>
+            DEVONN.AI — Promo Command Center
+          </div>
+
+          <h1 style={{ margin: 0, fontSize: 24, fontFamily: "system-ui, sans-serif", fontWeight: 800, color: "#fff", letterSpacing: "-0.03em" }}>
+            d3vonn.io
+          </h1>
+
+          <p style={{ fontSize: 12, color: BRAND.muted, marginTop: 6 }}>
+            Autonomous AI infrastructure · multi-agent orchestration · private beta
+          </p>
+
+          <div style={{ display: "flex", gap: 12, flexWrap: "wrap", marginTop: 16 }}>
+            <a href="https://d3vonn.io" target="_blank" rel="noreferrer" style={{ color: BRAND.bg, background: BRAND.accent, textDecoration: "none", borderRadius: 8, padding: "8px 14px", fontSize: 12, fontWeight: 700 }}>
+              OPEN D3VONN.IO
+            </a>
+
+            <CopyButton text={getChannelCopy(active)} label={`all ${active} content`} />
+          </div>
+        </header>
+
+        <nav aria-label="Promo content channels" style={{ display: "flex", gap: 0, borderBottom: `1px solid ${BRAND.borderSoft}`, overflowX: "auto" }}>
+          {CHANNELS.map((ch) => (
+            <button
+              key={ch.key}
+              onClick={() => setActive(ch.key)}
+              aria-pressed={active === ch.key}
+              style={{
+                background: "none",
+                border: "none",
+                borderBottom: active === ch.key ? `2px solid ${BRAND.accent}` : "2px solid transparent",
+                color: active === ch.key ? BRAND.accent : "#666",
+                padding: "12px 20px",
+                fontSize: 12,
+                fontFamily: "'JetBrains Mono', monospace",
+                cursor: "pointer",
+                whiteSpace: "nowrap",
+                transition: "color 0.15s",
+                letterSpacing: "0.05em",
+              }}
+            >
+              {ch.label}
+            </button>
+          ))}
+        </nav>
+
+        <section style={{ padding: "24px 24px 0" }}>{renderContent()}</section>
+
+        <footer style={{ margin: "32px 24px 0", padding: "16px", background: BRAND.panelSoft, border: `1px solid ${BRAND.borderSoft}`, borderRadius: 8, fontSize: 11, color: "#555", letterSpacing: "0.05em", lineHeight: 1.6 }}>
+          GITHUB → github.com/wesship/supreme-ai-deployment-hub &nbsp;·&nbsp; LIVE → d3vonn.io
+        </footer>
+      </div>
+    </main>
+  );
+}

--- a/src/components/navigation/navigationItems.ts
+++ b/src/components/navigation/navigationItems.ts
@@ -2,6 +2,7 @@ export const navigationItems = [
   { name: 'Platform', path: '/platform' },
   { name: 'Solutions', path: '/solutions' },
   { name: 'Agents', path: '/agents' },
+  { name: 'Marketing', path: '/marketing' },
   { name: 'Resources', path: '/resources' },
   { name: 'Security', path: '/security' },
   { name: 'Pricing', path: '/pricing' },

--- a/src/pages/MarketingCommandCenter.tsx
+++ b/src/pages/MarketingCommandCenter.tsx
@@ -1,0 +1,18 @@
+import { Helmet } from "react-helmet-async";
+import MarketingCommandCenterApp from "../components/MarketingCommandCenter";
+
+export default function MarketingCommandCenter() {
+  return (
+    <>
+      <Helmet>
+        <title>D3VONN Marketing Command Center | DEVONN.AI</title>
+        <meta
+          name="description"
+          content="D3VONN Marketing Command Center for campaign assets, brand review, claim governance, launch workflows, and reusable marketing operations."
+        />
+        <link rel="canonical" href="https://d3vonn.io/marketing" />
+      </Helmet>
+      <MarketingCommandCenterApp />
+    </>
+  );
+}

--- a/src/types/marketing.ts
+++ b/src/types/marketing.ts
@@ -1,0 +1,68 @@
+export type MarketingChannel =
+  | "x-twitter"
+  | "linkedin"
+  | "tiktok"
+  | "threads"
+  | "youtube-shorts"
+  | "instagram"
+  | "email"
+  | "github";
+
+export type MarketingContentStatus =
+  | "IDEA"
+  | "DRAFT"
+  | "BRAND_REVIEW"
+  | "CLAIM_CHECK"
+  | "APPROVED"
+  | "QUEUED"
+  | "LIVE"
+  | "MEASURED"
+  | "REPURPOSED";
+
+export type MarketingReviewDecision = "APPROVE" | "REVISE" | "BLOCK";
+
+export interface MarketingCampaign {
+  id: string;
+  name: string;
+  status: MarketingContentStatus;
+  primaryCta: string;
+  primaryMessage: string;
+  channels: MarketingChannel[];
+  createdAt?: string;
+  updatedAt?: string;
+}
+
+export interface MarketingAsset {
+  id: string;
+  campaignId?: string;
+  channel: MarketingChannel;
+  label: string;
+  subject?: string;
+  body: string;
+  status: MarketingContentStatus;
+  createdAt?: string;
+  updatedAt?: string;
+}
+
+export interface MarketingReviewResult {
+  decision: MarketingReviewDecision;
+  score?: number;
+  issues: string[];
+  suggestedRevision?: string;
+  requiredSources?: string[];
+}
+
+export interface MarketingGenerateRequest {
+  campaignName: string;
+  audience: string;
+  channel: MarketingChannel;
+  cta: string;
+  productUpdate: string;
+  constraints?: string[];
+}
+
+export interface MarketingGenerateResponse {
+  asset: MarketingAsset;
+  brandReview?: MarketingReviewResult;
+  claimReview?: MarketingReviewResult;
+}

--- a/supabase/migrations/20260626000001_marketing_command_center.sql
+++ b/supabase/migrations/20260626000001_marketing_command_center.sql
@@ -1,0 +1,87 @@
+-- D3VONN Marketing Command Center schema
+-- Stores campaigns, assets, review results, and analytics feedback loops.
+
+create table if not exists public.marketing_campaigns (
+  id uuid primary key default gen_random_uuid(),
+  owner_id uuid references auth.users(id) on delete set null,
+  slug text unique not null,
+  name text not null,
+  status text not null default 'DRAFT',
+  primary_cta text,
+  primary_message text,
+  channels text[] not null default '{}',
+  metadata jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create table if not exists public.marketing_assets (
+  id uuid primary key default gen_random_uuid(),
+  campaign_id uuid references public.marketing_campaigns(id) on delete cascade,
+  owner_id uuid references auth.users(id) on delete set null,
+  channel text not null,
+  label text not null,
+  subject text,
+  body text not null,
+  status text not null default 'DRAFT',
+  character_count integer generated always as (char_length(body)) stored,
+  metadata jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create table if not exists public.marketing_reviews (
+  id uuid primary key default gen_random_uuid(),
+  asset_id uuid references public.marketing_assets(id) on delete cascade,
+  reviewer_agent text not null,
+  decision text not null,
+  score numeric,
+  issues jsonb not null default '[]'::jsonb,
+  suggested_revision text,
+  required_sources jsonb not null default '[]'::jsonb,
+  created_at timestamptz not null default now()
+);
+
+create table if not exists public.marketing_metrics (
+  id uuid primary key default gen_random_uuid(),
+  campaign_id uuid references public.marketing_campaigns(id) on delete cascade,
+  asset_id uuid references public.marketing_assets(id) on delete cascade,
+  channel text not null,
+  metric_name text not null,
+  metric_value numeric not null default 0,
+  measured_at timestamptz not null default now(),
+  metadata jsonb not null default '{}'::jsonb
+);
+
+alter table public.marketing_campaigns enable row level security;
+alter table public.marketing_assets enable row level security;
+alter table public.marketing_reviews enable row level security;
+alter table public.marketing_metrics enable row level security;
+
+create policy "marketing_campaigns_owner_select" on public.marketing_campaigns
+  for select using (auth.uid() = owner_id);
+
+create policy "marketing_campaigns_owner_write" on public.marketing_campaigns
+  for all using (auth.uid() = owner_id) with check (auth.uid() = owner_id);
+
+create policy "marketing_assets_owner_select" on public.marketing_assets
+  for select using (auth.uid() = owner_id);
+
+create policy "marketing_assets_owner_write" on public.marketing_assets
+  for all using (auth.uid() = owner_id) with check (auth.uid() = owner_id);
+
+create policy "marketing_reviews_owner_select" on public.marketing_reviews
+  for select using (
+    exists (
+      select 1 from public.marketing_assets a
+      where a.id = marketing_reviews.asset_id and a.owner_id = auth.uid()
+    )
+  );
+
+create policy "marketing_metrics_owner_select" on public.marketing_metrics
+  for select using (
+    exists (
+      select 1 from public.marketing_campaigns c
+      where c.id = marketing_metrics.campaign_id and c.owner_id = auth.uid()
+    )
+  );


### PR DESCRIPTION
## Summary

Adds the end-to-end D3VONN Marketing Command Center foundation and wires the first usable integration path into the app.

## Included

- Marketing knowledge base under `/marketing`
- D3VONN marketing system prompt
- Brand guide
- Content workflow
- Hermes routing map
- Hermes integration plan
- Launch checklist
- Claim governance files
- Audience personas
- Proof points and metrics source-of-truth
- Agent role files for Marketing, Brand, Compliance, Launch, Analytics, Publisher, and Research agents
- Prompt pack for campaign generation, brand checks, claim checks, and platform optimization
- Private beta launch brief
- Social/email templates
- Reusable React component: `src/components/MarketingCommandCenter.jsx`
- Type declaration: `src/components/MarketingCommandCenter.d.ts`
- Page wrapper: `src/pages/MarketingCommandCenter.tsx`
- Live route registration: `/marketing`
- Main nav item: `Marketing`
- Frontend API client: `src/api/marketing/marketingApi.ts`
- Marketing domain types: `src/types/marketing.ts`
- FastAPI router: `backend/app/routers/marketing.py`
- Backend router registration under `/api/marketing/*`
- Supabase migration for campaigns, assets, reviews, and metrics
- Integration guide: `docs/integrations/MARKETING_COMMAND_CENTER_INTEGRATION.md`

## Safety / Governance

- External posting/sending is intentionally not implemented in this PR.
- Public channel movement remains human-approved.
- Claim-sensitive content runs through brand/claim review scaffolding.
- Exact metrics are routed through the metrics source-of-truth documentation before publication.

## Follow-up After Merge

1. Replace deterministic marketing API stubs with Hermes agent calls.
2. Move hardcoded UI content into Supabase-backed campaign records.
3. Add admin/role gating if `/marketing` should be private.
4. Add real analytics ingestion into `marketing_metrics`.
5. Add optional scheduling adapters after approval workflow is stable.