### PR TITLE
feat: add D3VONN proof, trust routes, demo CTA, and pricing tiers

### DIFF
--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -6,6 +6,11 @@
     <priority>1.0</priority>
   </url>
   <url>
+    <loc>https://d3vonn.io/demo</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.95</priority>
+  </url>
+  <url>
     <loc>https://d3vonn.io/solutions</loc>
     <changefreq>weekly</changefreq>
     <priority>0.95</priority>
@@ -19,6 +24,26 @@
     <loc>https://d3vonn.io/security</loc>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
+  </url>
+  <url>
+    <loc>https://d3vonn.io/docs</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
+    <loc>https://d3vonn.io/status</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
+    <loc>https://d3vonn.io/roadmap</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.85</priority>
+  </url>
+  <url>
+    <loc>https://d3vonn.io/case-studies</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.85</priority>
   </url>
   <url>
     <loc>https://d3vonn.io/resources</loc>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -81,6 +81,8 @@ const Resources = lazy(() => import("./pages/Resources"));
 const Security = lazy(() => import("./pages/Security"));
 const Pricing = lazy(() => import("./pages/Pricing"));
 const ResearchOS = lazy(() => import("./pages/ResearchOS"));
+const Roadmap = lazy(() => import("./pages/Roadmap"));
+const CaseStudies = lazy(() => import("./pages/CaseStudies"));
 
 // Wrapper for AdminRoute since lazy components can't directly accept children as JSX
 const AdminRouteWrapper = lazy(() =>
@@ -156,6 +158,7 @@ function App() {
                 <Route path="/deployment" element={<DeploymentDashboard />} />
                 <Route path="/api" element={<APIManagement />} />
                 <Route path="/documentation" element={<Documentation />} />
+                <Route path="/docs" element={<Documentation />} />
                 <Route path="/agents" element={<AgentDashboard />} />
                 <Route path="/devonn" element={<DevonnDashboard />} />
                 <Route path="/flow" element={<FlowEditor />} />
@@ -168,6 +171,8 @@ function App() {
                 <Route path="/manifest" element={<ManifestPage />} />
                 <Route path="/github-diagnostic" element={<GitHubConnectorDiagnostic />} />
                 <Route path="/command-center" element={<CommandCenter />} />
+                <Route path="/demo" element={<CommandCenter />} />
+                <Route path="/command-center-demo" element={<CommandCenter />} />
                 <Route path="/about" element={<About />} />
                 <Route path="/contact" element={<Contact />} />
                 <Route path="/terms" element={<Terms />} />
@@ -194,6 +199,8 @@ function App() {
                 <Route path="/security" element={<Security />} />
                 <Route path="/pricing" element={<Pricing />} />
                 <Route path="/research-os" element={<ResearchOS />} />
+                <Route path="/roadmap" element={<Roadmap />} />
+                <Route path="/case-studies" element={<CaseStudies />} />
                 <Route path="/platform" element={<Navigate to="/#platform" replace />} />
                 <Route path="/signin" element={<Navigate to="/login" replace />} />
                 <Route path="/signup" element={<Navigate to="/login" replace />} />

--- a/src/components/navigation/navigationItems.ts
+++ b/src/components/navigation/navigationItems.ts
@@ -1,8 +1,11 @@
 export const navigationItems = [
   { name: 'Platform', path: '/platform' },
   { name: 'Solutions', path: '/solutions' },
-  { name: 'Agents', path: '/agents' },
-  { name: 'Resources', path: '/resources' },
+  { name: 'Demo', path: '/demo' },
+  { name: 'Docs', path: '/docs' },
+  { name: 'Status', path: '/status' },
+  { name: 'Roadmap', path: '/roadmap' },
   { name: 'Security', path: '/security' },
   { name: 'Pricing', path: '/pricing' },
+  { name: 'Case Studies', path: '/case-studies' },
 ];

--- a/src/pages/CaseStudies.tsx
+++ b/src/pages/CaseStudies.tsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import { Helmet } from 'react-helmet-async';
+import { Link } from 'react-router-dom';
+import { ArrowRight, BarChart3, Bot, CheckCircle2, Workflow } from 'lucide-react';
+
+const studies = [
+  { title: 'Founder Command Center', icon: Bot, outcome: 'Turn scattered goals into visible agent tasks.', details: ['Hermes plans tasks and checkpoints', 'Command Center shows active work', 'Human approvals stay in the loop'] },
+  { title: 'Research Operating Layer', icon: BarChart3, outcome: 'Produce structured briefs from internet, market, and lead research.', details: ['Reusable research workflows', 'RAG-backed context capture', 'Decision-ready summaries'] },
+  { title: 'Workflow Automation Pilot', icon: Workflow, outcome: 'Package one repeated operation into a measurable workflow.', details: ['Define the goal', 'Assign agent roles', 'Measure cycle time and quality'] },
+];
+
+const CaseStudies: React.FC = () => {
+  const title = 'Case Studies — D3VONN.IO';
+  const description = 'D3VONN.IO case-study patterns for founder operations, research workflows, and measurable AI workforce pilots.';
+
+  return (
+    <div className="min-h-screen bg-[#020817] text-white">
+      <Helmet>
+        <title>{title}</title>
+        <meta name="description" content={description} />
+        <link rel="canonical" href="https://d3vonn.io/case-studies" />
+        <meta property="og:title" content={title} />
+        <meta property="og:description" content={description} />
+        <meta property="og:type" content="website" />
+      </Helmet>
+      <main className="container mx-auto px-6 py-24">
+        <section className="mx-auto max-w-4xl text-center">
+          <p className="text-xs font-semibold uppercase tracking-[0.2em] text-blue-400">Case Studies</p>
+          <h1 className="mt-6 text-4xl font-black tracking-tight sm:text-6xl">Pilot patterns for a <span className="text-blue-400">real AI workforce</span>.</h1>
+          <p className="mt-6 text-lg text-white/70">Start with a measurable workflow, prove the value, then expand the Command Center into more business operations.</p>
+        </section>
+        <section className="mt-16 grid gap-6 lg:grid-cols-3">
+          {studies.map((study) => (
+            <article key={study.title} className="rounded-2xl border border-white/10 bg-white/[0.03] p-6 shadow-[0_0_40px_-12px_rgba(56,136,255,0.25)]">
+              <div className="flex h-12 w-12 items-center justify-center rounded-xl border border-blue-500/25 bg-blue-950/50 text-blue-300"><study.icon className="h-6 w-6" /></div>
+              <h2 className="mt-5 text-2xl font-black">{study.title}</h2>
+              <p className="mt-3 text-white/70">{study.outcome}</p>
+              <ul className="mt-6 space-y-3">
+                {study.details.map((detail) => <li key={detail} className="flex gap-3 text-sm text-white/70"><CheckCircle2 className="mt-0.5 h-4 w-4 shrink-0 text-blue-400" />{detail}</li>)}
+              </ul>
+            </article>
+          ))}
+        </section>
+        <section className="mt-16 rounded-3xl border border-blue-500/20 bg-blue-950/20 p-8 text-center">
+          <h2 className="text-3xl font-black">Build the next public case study.</h2>
+          <p className="mx-auto mt-3 max-w-2xl text-white/70">Pick one workflow with a clear input, output, approval point, and measurable business result.</p>
+          <Link to="/contact?inquiry=case-study-pilot" className="mt-8 inline-flex items-center justify-center gap-2 rounded-xl bg-blue-600 px-6 py-3 font-semibold text-white hover:bg-blue-500">Plan a Pilot <ArrowRight className="h-4 w-4" /></Link>
+        </section>
+      </main>
+    </div>
+  );
+};
+
+export default CaseStudies;

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -27,6 +27,15 @@ const GlassCard: React.FC<React.HTMLAttributes<HTMLDivElement>> = ({
   </div>
 );
 
+const proofPoints = [
+  '573 tests passing',
+  '41/41 CI checks',
+  'Railway API live',
+  'Vercel frontend live',
+  'Supabase + Pinecone RAG',
+  'Hermes orchestrator',
+];
+
 const Hero: React.FC = () => (
   <section
     aria-label="D3VONN.IO — AI Business Operating System"
@@ -61,19 +70,34 @@ const Hero: React.FC = () => (
         </h1>
 
         <p className="mt-6 max-w-2xl text-xl font-semibold text-white/90 sm:text-2xl">
-          D3VONN.IO turns business goals into supervised agent execution — planning, workflows, memory, approvals, and command-center visibility.
+          D3VONN.IO is an AI Business Operating System that lets founders deploy, monitor, and control autonomous AI workers across sales, support, research, DevOps, and operations.
         </p>
         <p className="mt-4 max-w-xl text-base text-white/70">
-          One operating system for autonomous business work: Hermes orchestrates, agents execute, and you stay in control.
+          Hermes orchestrates the work, agents execute the run, and your Command Center keeps every task visible, governed, and ready for human approval.
         </p>
 
+        <div className="mt-8 grid max-w-3xl grid-cols-2 gap-3 sm:grid-cols-3">
+          {proofPoints.map((point) => (
+            <div key={point} className="rounded-xl border border-white/10 bg-white/[0.04] px-3 py-3 text-xs font-semibold text-white/75 backdrop-blur">
+              <span className="mr-2 inline-block h-2 w-2 rounded-full bg-blue-400 shadow-[0_0_12px_rgba(96,165,250,0.8)]" />
+              {point}
+            </div>
+          ))}
+        </div>
+
         <div className="mt-10 flex flex-col gap-4 sm:flex-row">
-          <SmartLaunchLink
-            authedTo="/app"
+          <Link
+            to="/demo"
             className="group inline-flex items-center justify-center gap-2 rounded-xl bg-blue-600 px-7 py-4 font-semibold text-white shadow-[0_0_30px_rgba(56,136,255,0.4)] transition hover:scale-[1.02] hover:bg-blue-500 hover:shadow-[0_0_50px_rgba(56,136,255,0.6)]"
           >
-            Launch D3VONN
+            Launch Command Center Demo
             <ArrowRight className="h-4 w-4 transition-transform group-hover:translate-x-1" />
+          </Link>
+          <SmartLaunchLink
+            authedTo="/app"
+            className="inline-flex items-center justify-center gap-2 rounded-xl border border-white/20 bg-white/5 px-7 py-4 font-semibold text-white backdrop-blur transition hover:border-blue-400/40 hover:bg-white/10"
+          >
+            Launch D3VONN
           </SmartLaunchLink>
           <Link
             to="/solutions"
@@ -87,9 +111,15 @@ const Hero: React.FC = () => (
         <div className="mt-8 flex flex-wrap items-center gap-3 text-xs text-white/60">
           <span className="inline-flex items-center gap-2"><ShieldCheck className="h-4 w-4 text-blue-400" />Secure by design</span>
           <span className="hidden h-1 w-1 rounded-full bg-white/30 sm:inline-block" />
-          <span>Observable agent runs</span>
+          <Link to="/security" className="hover:text-blue-300">Security</Link>
           <span className="hidden h-1 w-1 rounded-full bg-white/30 sm:inline-block" />
-          <span>Enterprise pilot ready</span>
+          <Link to="/docs" className="hover:text-blue-300">Docs</Link>
+          <span className="hidden h-1 w-1 rounded-full bg-white/30 sm:inline-block" />
+          <Link to="/status" className="hover:text-blue-300">Status</Link>
+          <span className="hidden h-1 w-1 rounded-full bg-white/30 sm:inline-block" />
+          <Link to="/roadmap" className="hover:text-blue-300">Roadmap</Link>
+          <span className="hidden h-1 w-1 rounded-full bg-white/30 sm:inline-block" />
+          <Link to="/case-studies" className="hover:text-blue-300">Case Studies</Link>
         </div>
       </div>
     </div>
@@ -175,7 +205,7 @@ const Index: React.FC = () => {
 
   const title = 'D3VONN.IO — AI Business Operating System';
   const description =
-    'D3VONN.IO is an AI Business Operating System that turns business goals into supervised agent execution with Hermes orchestration, workflows, memory, and command-center visibility.';
+    'D3VONN.IO lets founders deploy, monitor, and control autonomous AI workers across sales, support, research, DevOps, and operations.';
   const url = 'https://d3vonn.io/';
 
   return (

--- a/src/pages/Pricing.tsx
+++ b/src/pages/Pricing.tsx
@@ -1,17 +1,61 @@
 import React from 'react';
 import { Helmet } from 'react-helmet-async';
 import { Link } from 'react-router-dom';
-import { ArrowRight, Check, ShieldCheck } from 'lucide-react';
+import { ArrowRight, Check, ShieldCheck, Sparkles } from 'lucide-react';
 
 const plans = [
-  { name: 'Starter', price: '$0', period: 'forever', desc: 'Explore AI agents and basic workflows.', features: ['3 active agents', 'Community marketplace', 'Basic observability', 'Starter workflow templates'], cta: 'Start free', href: '/login' },
-  { name: 'Operator', price: '$49', period: 'per month', desc: 'Run a practical AI workforce for real business tasks.', features: ['Unlimited agents', 'Hermes mesh access', 'RAG knowledge vault', 'Priority support', 'Production workflow runs'], cta: 'Launch Operator', href: '/login', featured: true },
-  { name: 'Enterprise', price: 'Custom', period: 'annual contract', desc: 'For teams needing governance, custom integrations, and deployment flexibility.', features: ['SSO/RBAC roadmap', 'Security review support', 'Dedicated implementation', 'Private/VPC deployment path', 'Custom agent bundles'], cta: 'Schedule demo', href: '/contact?inquiry=enterprise-demo' },
+  {
+    name: 'Starter',
+    price: '$0',
+    period: 'per month',
+    desc: 'Explore the AI Business Operating System and prove one workflow.',
+    features: ['3 active agents', 'Community marketplace', 'Basic observability', 'Starter workflow templates', 'Command Center preview'],
+    cta: 'Start Free',
+    href: '/signup?plan=starter',
+  },
+  {
+    name: 'Operator',
+    price: '$49',
+    period: 'per month',
+    desc: 'Run a practical AI workforce for founder-led operations.',
+    features: ['Unlimited draft agents', 'Hermes orchestration', 'RAG knowledge vault', 'Production workflow runs', 'Priority onboarding path'],
+    cta: 'Start Operating',
+    href: '/signup?plan=operator',
+    featured: true,
+  },
+  {
+    name: 'Pro',
+    price: '$149',
+    period: 'per month',
+    desc: 'Scale repeatable workflows across sales, support, research, and DevOps.',
+    features: ['Advanced agent bundles', 'Approval checkpoints', 'Workflow templates', 'Enhanced reporting', 'Higher run limits'],
+    cta: 'Upgrade to Pro',
+    href: '/signup?plan=pro',
+  },
+  {
+    name: 'Business',
+    price: '$499',
+    period: 'per month',
+    desc: 'Build a governed AI workforce for a small team or department.',
+    features: ['Team workspaces', 'Business workflow library', 'Admin visibility', 'Implementation support', 'Case-study pilot design'],
+    cta: 'Build Your AI Workforce',
+    href: '/signup?plan=business',
+    badge: 'Best for teams',
+  },
+  {
+    name: 'Enterprise',
+    price: 'Custom',
+    period: 'annual contract',
+    desc: 'For organizations needing governance, integrations, and deployment flexibility.',
+    features: ['SSO/RBAC roadmap', 'Security review support', 'Dedicated implementation', 'Private/VPC deployment path', 'Custom agent bundles'],
+    cta: 'Contact Sales',
+    href: '/contact?inquiry=enterprise',
+  },
 ];
 
 const Pricing: React.FC = () => {
   const title = 'Pricing — D3VONN.IO';
-  const description = 'D3VONN.IO pricing for Starter, Operator, and Enterprise AI workforce orchestration plans.';
+  const description = 'D3VONN.IO pricing for Starter, Operator, Pro, Business, and Enterprise AI Business Operating System plans.';
 
   return (
     <div className="min-h-screen bg-[#020817] text-white">
@@ -31,21 +75,22 @@ const Pricing: React.FC = () => {
             Clear pricing for building your <span className="text-blue-400">AI workforce</span>.
           </h1>
           <p className="mt-6 text-lg text-white/70">
-            Start small, prove one workflow, then scale into a governed AI operating layer for your business.
+            Start free, move into operations, then scale into a governed AI operating layer for your business.
           </p>
         </section>
 
-        <section className="mt-16 grid gap-6 lg:grid-cols-3">
+        <section className="mt-16 grid gap-6 lg:grid-cols-5">
           {plans.map((plan) => (
-            <article key={plan.name} className={`relative rounded-2xl border bg-white/[0.03] p-6 shadow-[0_0_40px_-12px_rgba(56,136,255,0.25)] ${plan.featured ? 'border-blue-500/50' : 'border-white/10'}`}>
+            <article key={plan.name} className={`relative flex h-full flex-col rounded-2xl border bg-white/[0.03] p-6 shadow-[0_0_40px_-12px_rgba(56,136,255,0.25)] ${plan.featured ? 'border-blue-500/50 bg-blue-950/20' : 'border-white/10'}`}>
               {plan.featured && <div className="absolute -top-3 left-6 rounded-full bg-blue-600 px-3 py-1 text-[10px] font-semibold uppercase tracking-widest">Most popular</div>}
+              {plan.badge && <div className="absolute -top-3 left-6 rounded-full bg-purple-600 px-3 py-1 text-[10px] font-semibold uppercase tracking-widest">{plan.badge}</div>}
               <h2 className="text-2xl font-black">{plan.name}</h2>
-              <p className="mt-3 text-sm text-white/65">{plan.desc}</p>
+              <p className="mt-3 min-h-[72px] text-sm text-white/65">{plan.desc}</p>
               <div className="mt-6 flex items-baseline gap-2">
-                <span className="text-5xl font-black">{plan.price}</span>
+                <span className="text-4xl font-black xl:text-5xl">{plan.price}</span>
                 <span className="text-sm text-white/50">{plan.period}</span>
               </div>
-              <ul className="mt-6 space-y-3">
+              <ul className="mt-6 flex-1 space-y-3">
                 {plan.features.map((feature) => (
                   <li key={feature} className="flex gap-3 text-sm text-white/75">
                     <Check className="mt-0.5 h-4 w-4 shrink-0 text-blue-400" />
@@ -60,12 +105,23 @@ const Pricing: React.FC = () => {
           ))}
         </section>
 
-        <section className="mt-16 rounded-3xl border border-blue-500/20 bg-blue-950/20 p-8 text-center">
-          <ShieldCheck className="mx-auto h-10 w-10 text-blue-300" />
-          <h2 className="mt-4 text-3xl font-black">Enterprise pilots should start with one measurable workflow.</h2>
-          <p className="mx-auto mt-3 max-w-2xl text-white/70">
-            The highest-value first pilot is usually a repeatable workflow with clear time savings, visible output quality, and measurable human approval points.
-          </p>
+        <section className="mt-16 grid gap-6 rounded-3xl border border-blue-500/20 bg-blue-950/20 p-8 lg:grid-cols-[0.8fr_1.2fr]">
+          <div className="text-center lg:text-left">
+            <ShieldCheck className="mx-auto h-10 w-10 text-blue-300 lg:mx-0" />
+            <h2 className="mt-4 text-3xl font-black">Enterprise pilots should start with one measurable workflow.</h2>
+            <p className="mt-3 text-white/70">
+              The highest-value first pilot is usually repeatable, visible, and measurable: clear time savings, strong output quality, and human approval points.
+            </p>
+          </div>
+          <div className="grid gap-4 sm:grid-cols-2">
+            {['Sales research', 'Support triage', 'Research briefings', 'DevOps monitoring'].map((useCase) => (
+              <div key={useCase} className="rounded-2xl border border-white/10 bg-black/25 p-5">
+                <Sparkles className="h-5 w-5 text-blue-300" />
+                <p className="mt-3 font-semibold">{useCase}</p>
+                <p className="mt-2 text-sm text-white/60">Deploy one workflow, measure the run, then expand the agent workforce.</p>
+              </div>
+            ))}
+          </div>
         </section>
       </main>
     </div>

--- a/src/pages/Roadmap.tsx
+++ b/src/pages/Roadmap.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import { Helmet } from 'react-helmet-async';
+import { Link } from 'react-router-dom';
+import { ArrowRight, CheckCircle2, Clock, Compass, Rocket } from 'lucide-react';
+
+const roadmap = [
+  { phase: 'Now', title: 'Production credibility layer', icon: CheckCircle2, items: ['Proof bar above the fold', 'Command Center demo route', 'Security, docs, status, roadmap, and case-study pages', 'Starter-to-Enterprise pricing ladder'] },
+  { phase: 'Next', title: 'Pilot workflow packaging', icon: Rocket, items: ['Founder workflow templates', 'Sales, research, support, and DevOps agent bundles', 'Demo-to-signup funnel', 'Public pilot intake workflow'] },
+  { phase: 'Soon', title: 'Enterprise trust maturity', icon: Clock, items: ['Audit log export', 'SSO and RBAC readiness', 'Security review packet', 'Compliance mapping for regulated pilots'] },
+  { phase: 'Future', title: 'Business OS expansion', icon: Compass, items: ['Agent marketplace expansion', 'Private deployment path', 'Advanced memory governance', 'Cross-team Command Center workspaces'] },
+];
+
+const Roadmap: React.FC = () => {
+  const title = 'Roadmap — D3VONN.IO';
+  const description = 'D3VONN.IO roadmap for the AI Business Operating System, Command Center, Hermes orchestration, enterprise trust, and AI workforce expansion.';
+
+  return (
+    <div className="min-h-screen bg-[#020817] text-white">
+      <Helmet>
+        <title>{title}</title>
+        <meta name="description" content={description} />
+        <link rel="canonical" href="https://d3vonn.io/roadmap" />
+        <meta property="og:title" content={title} />
+        <meta property="og:description" content={description} />
+        <meta property="og:type" content="website" />
+      </Helmet>
+      <main className="container mx-auto px-6 py-24">
+        <section className="mx-auto max-w-4xl text-center">
+          <p className="text-xs font-semibold uppercase tracking-[0.2em] text-blue-400">Roadmap</p>
+          <h1 className="mt-6 text-4xl font-black tracking-tight sm:text-6xl">From production proof to <span className="text-blue-400">business OS</span>.</h1>
+          <p className="mt-6 text-lg text-white/70">D3VONN.IO is moving from a verified AI operating layer into packaged pilots, trust maturity, and enterprise-grade multi-agent workspaces.</p>
+        </section>
+        <section className="mt-16 grid gap-6 lg:grid-cols-4">
+          {roadmap.map((section) => (
+            <article key={section.phase} className="rounded-2xl border border-white/10 bg-white/[0.03] p-6 shadow-[0_0_40px_-12px_rgba(56,136,255,0.25)]">
+              <div className="flex h-12 w-12 items-center justify-center rounded-xl border border-blue-500/25 bg-blue-950/50 text-blue-300"><section.icon className="h-6 w-6" /></div>
+              <p className="mt-5 text-xs font-semibold uppercase tracking-[0.18em] text-blue-300">{section.phase}</p>
+              <h2 className="mt-2 text-xl font-black">{section.title}</h2>
+              <ul className="mt-5 space-y-3">
+                {section.items.map((item) => <li key={item} className="flex gap-3 text-sm text-white/70"><CheckCircle2 className="mt-0.5 h-4 w-4 shrink-0 text-blue-400" />{item}</li>)}
+              </ul>
+            </article>
+          ))}
+        </section>
+        <section className="mt-16 rounded-3xl border border-blue-500/20 bg-blue-950/20 p-8 text-center">
+          <h2 className="text-3xl font-black">Ready to see the command layer?</h2>
+          <p className="mx-auto mt-3 max-w-2xl text-white/70">Start with the public Command Center demo, then move into a measurable founder workflow pilot.</p>
+          <Link to="/demo" className="mt-8 inline-flex items-center justify-center gap-2 rounded-xl bg-blue-600 px-6 py-3 font-semibold text-white hover:bg-blue-500">Launch Command Center Demo <ArrowRight className="h-4 w-4" /></Link>
+        </section>
+      </main>
+    </div>
+  );
+};
+
+export default Roadmap;


### PR DESCRIPTION
## Summary
- Adds homepage production proof above the fold: 573 tests passing, 41/41 CI checks, Railway API live, Vercel frontend live, Supabase + Pinecone RAG, Hermes orchestrator
- Replaces the hero offer language with the sharper AI Business Operating System positioning
- Adds a public `Launch Command Center Demo` CTA routed through `/demo` and `/command-center-demo`
- Expands pricing to Starter, Operator, Pro, Business, and Enterprise
- Adds `/docs`, `/roadmap`, `/case-studies`, `/demo`, and `/command-center-demo` routes
- Adds Roadmap and Case Studies trust pages
- Updates nav and sitemap for the new trust/demo routes

## Notes
- This branch was created from `main` as `feat/d3vonn-proof-trust-pricing`.
- I did not run local `pnpm build` or `pnpm lint` from this connector session; CI should validate TypeScript, routing, and formatting.