### PR TITLE
Fix user Google Drive authorization for agent uploads

### DIFF
--- a/docs/integrations/GOOGLE_DRIVE_USER_AUTH.md
+++ b/docs/integrations/GOOGLE_DRIVE_USER_AUTH.md
@@ -1,0 +1,88 @@
+# Google Drive Per-User Authorization
+
+## Goal
+
+D3VONN.IO must let each user connect their own Google Drive account. The app should not rely on the founder account, a shared Drive connection, or any server-side personal credential for user file access.
+
+## Current Error
+
+If the browser or app shows:
+
+```text
+Unsupported provider: provider is not enabled
+```
+
+that means the Google OAuth provider has not been enabled/configured in Supabase Auth for this project, or the redirect URL does not match the configured OAuth application.
+
+## Required Supabase Setup
+
+In Supabase:
+
+1. Go to **Authentication → Providers → Google**.
+2. Enable Google.
+3. Add the Google OAuth client ID and client secret.
+4. Add site URL:
+
+```text
+https://d3vonn.io
+```
+
+5. Add redirect URLs:
+
+```text
+https://d3vonn.io/auth/callback
+https://www.d3vonn.io/auth/callback
+http://localhost:5173/auth/callback
+```
+
+## Required Google Cloud Setup
+
+In Google Cloud Console:
+
+1. Create or select the D3VONN.IO OAuth app.
+2. Enable Google Drive API.
+3. Add authorized JavaScript origins:
+
+```text
+https://d3vonn.io
+https://www.d3vonn.io
+http://localhost:5173
+```
+
+4. Add authorized redirect URIs:
+
+```text
+https://<SUPABASE_PROJECT_REF>.supabase.co/auth/v1/callback
+```
+
+5. Request only the minimum scopes needed:
+
+```text
+openid
+email
+profile
+https://www.googleapis.com/auth/drive.file
+```
+
+## Why `drive.file`
+
+Use `drive.file`, not full-drive access. This gives D3VONN access only to files the user explicitly opens, creates, or authorizes through the app.
+
+## Product Rule
+
+Every Drive authorization must be user-owned:
+
+- User signs in with their own Google account.
+- User grants D3VONN permission.
+- User-selected files are uploaded or processed for that user only.
+- No founder-owned Google Drive account should be used as a shared provider.
+
+## Follow-up Backend Work
+
+The current UI starts the Google OAuth flow with Drive scope. The production backend should add:
+
+1. A per-user Drive connection table.
+2. Encrypted token storage if provider tokens are persisted.
+3. A file import endpoint that associates selected Drive files with the authenticated user.
+4. Row-level security so users only see their own imported files.
+5. Token revocation/disconnect support.

--- a/docs/integrations/GOOGLE_DRIVE_USER_AUTH.md
+++ b/docs/integrations/GOOGLE_DRIVE_USER_AUTH.md
@@ -52,7 +52,7 @@ http://localhost:5173
 4. Add authorized redirect URIs:
 
 ```text
-https://<SUPABASE_PROJECT_REF>.supabase.co/auth/v1/callback
+https://tjygexesognbkwualywq.supabase.co/auth/v1/callback
 ```
 
 5. Request only the minimum scopes needed:
@@ -77,12 +77,28 @@ Every Drive authorization must be user-owned:
 - User-selected files are uploaded or processed for that user only.
 - No founder-owned Google Drive account should be used as a shared provider.
 
+## Upload Source UX
+
+The Agent Manager should present upload sources as user-owned connectors:
+
+- Local Device
+- Google Drive
+- OneDrive
+- Dropbox
+- Notion
+- Confluence
+- GitHub Repository
+- URL
+
+Only Local Device and Google Drive are active in this release. The other connectors are visible as roadmap items so users understand where the knowledge-ingestion system is going.
+
 ## Follow-up Backend Work
 
 The current UI starts the Google OAuth flow with Drive scope. The production backend should add:
 
 1. A per-user Drive connection table.
 2. Encrypted token storage if provider tokens are persisted.
-3. A file import endpoint that associates selected Drive files with the authenticated user.
+3. A Google Picker or Drive file import endpoint that associates selected Drive files with the authenticated user.
 4. Row-level security so users only see their own imported files.
 5. Token revocation/disconnect support.
+6. Future OAuth connector tables for OneDrive, Dropbox, Notion, Confluence, and GitHub.

--- a/src/components/agent/tabs/CreateAgentTab.tsx
+++ b/src/components/agent/tabs/CreateAgentTab.tsx
@@ -6,7 +6,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Checkbox } from "@/components/ui/checkbox";
 import { ScrollArea } from "@/components/ui/scroll-area";
-import { Sparkles, Loader2, FileUp, Cloud } from "lucide-react";
+import { Sparkles, Loader2, FileUp, Cloud, FolderOpen, Box, FileText, Github, Link as LinkIcon } from "lucide-react";
 import { Task, AgentResponse } from "@/types/agent";
 import { toast } from "sonner";
 import { agentApi } from "@/api/agentApi";
@@ -35,6 +35,15 @@ const googleDriveScopes = [
   "profile",
   "https://www.googleapis.com/auth/drive.file",
 ].join(" ");
+
+const upcomingSources = [
+  { label: "OneDrive", icon: Cloud },
+  { label: "Dropbox", icon: Box },
+  { label: "Notion", icon: FileText },
+  { label: "Confluence", icon: FileText },
+  { label: "GitHub Repository", icon: Github },
+  { label: "URL", icon: LinkIcon },
+];
 
 const CreateAgentTab: React.FC<CreateAgentTabProps> = ({
   taskDescription,
@@ -105,6 +114,10 @@ const CreateAgentTab: React.FC<CreateAgentTabProps> = ({
       toast.error(message);
       setDriveConnecting(false);
     }
+  };
+
+  const handleComingSoon = (source: string) => {
+    toast.info(`${source} connector is planned. Google Drive and local uploads are the active sources for this release.`);
   };
 
   const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -179,36 +192,60 @@ const CreateAgentTab: React.FC<CreateAgentTabProps> = ({
               />
             </div>
           )}
-          <div className="space-y-2">
-            <Label htmlFor="fileUpload">Upload Task File (Optional)</Label>
-            <div className="rounded-lg border border-border/70 bg-muted/20 p-3 text-sm text-muted-foreground">
-              Users must authorize their own Google account. D3VONN should never browse or reuse the founder account's Drive files.
+          <div className="space-y-3">
+            <div>
+              <Label>Upload Knowledge Source</Label>
+              <p className="mt-1 text-xs text-muted-foreground">
+                Each user connects their own account. D3VONN does not reuse the founder's Drive files.
+              </p>
             </div>
-            <Button
-              type="button"
-              variant="outline"
-              onClick={handleConnectGoogleDrive}
-              disabled={driveConnecting}
-              className="w-full justify-center"
-            >
-              {driveConnecting ? <Loader2 className="h-4 w-4 mr-2 animate-spin" /> : <Cloud className="h-4 w-4 mr-2" />}
-              {driveConnecting ? "Connecting Google Drive..." : "Connect My Google Drive"}
-            </Button>
-            <Input 
-              id="fileUpload" 
-              type="file" 
-              onChange={handleFileChange} 
-            />
-            {file && (
-              <Button 
-                variant="secondary" 
-                size="sm" 
-                onClick={handleUploadFile}
-                className="mt-2"
+            <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+              <label className="flex min-h-12 cursor-pointer items-center justify-center gap-2 rounded-lg border border-border bg-background/60 px-3 py-2 text-sm font-medium hover:bg-muted/40">
+                <FolderOpen className="h-4 w-4" />
+                Local Device
+                <Input 
+                  id="fileUpload" 
+                  type="file" 
+                  onChange={handleFileChange}
+                  className="sr-only" 
+                />
+              </label>
+              <Button
+                type="button"
+                variant="outline"
+                onClick={handleConnectGoogleDrive}
+                disabled={driveConnecting}
+                className="min-h-12 justify-center"
               >
-                <FileUp className="h-4 w-4 mr-2" />
-                Upload File
+                {driveConnecting ? <Loader2 className="h-4 w-4 mr-2 animate-spin" /> : <Cloud className="h-4 w-4 mr-2" />}
+                {driveConnecting ? "Connecting..." : "Google Drive"}
               </Button>
+              {upcomingSources.map(({ label, icon: Icon }) => (
+                <Button
+                  key={label}
+                  type="button"
+                  variant="outline"
+                  onClick={() => handleComingSoon(label)}
+                  className="min-h-12 justify-center opacity-75"
+                >
+                  <Icon className="h-4 w-4 mr-2" />
+                  {label}
+                </Button>
+              ))}
+            </div>
+            {file && (
+              <div className="rounded-lg border border-border/70 bg-muted/20 p-3">
+                <p className="text-sm text-muted-foreground">Selected file: <span className="font-medium text-foreground">{file.name}</span></p>
+                <Button 
+                  variant="secondary" 
+                  size="sm" 
+                  onClick={handleUploadFile}
+                  className="mt-2"
+                >
+                  <FileUp className="h-4 w-4 mr-2" />
+                  Upload File
+                </Button>
+              </div>
             )}
           </div>
         </CardContent>

--- a/src/components/agent/tabs/CreateAgentTab.tsx
+++ b/src/components/agent/tabs/CreateAgentTab.tsx
@@ -1,4 +1,3 @@
-
 import React, { useState } from "react";
 import { Card, CardHeader, CardTitle, CardDescription, CardContent, CardFooter } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
@@ -7,10 +6,11 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Checkbox } from "@/components/ui/checkbox";
 import { ScrollArea } from "@/components/ui/scroll-area";
-import { Sparkles, Loader2, FileUp } from "lucide-react";
+import { Sparkles, Loader2, FileUp, Cloud } from "lucide-react";
 import { Task, AgentResponse } from "@/types/agent";
 import { toast } from "sonner";
 import { agentApi } from "@/api/agentApi";
+import { supabase } from "@/integrations/supabase/client";
 
 interface CreateAgentTabProps {
   taskDescription: string;
@@ -29,6 +29,13 @@ interface CreateAgentTabProps {
   setActiveTab: (tab: string) => void;
 }
 
+const googleDriveScopes = [
+  "openid",
+  "email",
+  "profile",
+  "https://www.googleapis.com/auth/drive.file",
+].join(" ");
+
 const CreateAgentTab: React.FC<CreateAgentTabProps> = ({
   taskDescription,
   setTaskDescription,
@@ -45,6 +52,8 @@ const CreateAgentTab: React.FC<CreateAgentTabProps> = ({
   generateAgent,
   setActiveTab,
 }) => {
+  const [driveConnecting, setDriveConnecting] = useState(false);
+
   const handleGenerateAgent = async () => {
     if (!taskDescription) {
       toast.error("Please enter a task description");
@@ -62,6 +71,39 @@ const CreateAgentTab: React.FC<CreateAgentTabProps> = ({
       setActiveTab("manage");
     } catch (error) {
       console.error("Error generating agent:", error);
+    }
+  };
+
+  const handleConnectGoogleDrive = async () => {
+    setDriveConnecting(true);
+
+    try {
+      const redirectTo = `${window.location.origin}/auth/callback?redirect=${encodeURIComponent(window.location.pathname)}`;
+      const { error } = await supabase.auth.signInWithOAuth({
+        provider: "google",
+        options: {
+          redirectTo,
+          scopes: googleDriveScopes,
+          queryParams: {
+            access_type: "offline",
+            prompt: "consent",
+          },
+        },
+      });
+
+      if (error) {
+        const message = error.message || "Google Drive authorization failed";
+        if (message.toLowerCase().includes("unsupported provider") || message.toLowerCase().includes("not enabled")) {
+          toast.error("Google OAuth is not enabled in Supabase yet. Enable Google provider so each user can connect their own Drive account.");
+        } else {
+          toast.error(message);
+        }
+        setDriveConnecting(false);
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Google Drive authorization failed";
+      toast.error(message);
+      setDriveConnecting(false);
     }
   };
 
@@ -139,6 +181,19 @@ const CreateAgentTab: React.FC<CreateAgentTabProps> = ({
           )}
           <div className="space-y-2">
             <Label htmlFor="fileUpload">Upload Task File (Optional)</Label>
+            <div className="rounded-lg border border-border/70 bg-muted/20 p-3 text-sm text-muted-foreground">
+              Users must authorize their own Google account. D3VONN should never browse or reuse the founder account's Drive files.
+            </div>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={handleConnectGoogleDrive}
+              disabled={driveConnecting}
+              className="w-full justify-center"
+            >
+              {driveConnecting ? <Loader2 className="h-4 w-4 mr-2 animate-spin" /> : <Cloud className="h-4 w-4 mr-2" />}
+              {driveConnecting ? "Connecting Google Drive..." : "Connect My Google Drive"}
+            </Button>
             <Input 
               id="fileUpload" 
               type="file" 


### PR DESCRIPTION
## Summary
- Adds a Connect My Google Drive OAuth action to the AI Agent file upload flow.
- Uses per-user Google OAuth with the least-privilege drive.file scope.
- Adds guidance that every user should authorize their own Google account.
- Adds setup documentation for enabling Google provider in Supabase and Google Drive API in Google Cloud.

## Required configuration
Enable Google in Supabase Auth and configure the Google Cloud OAuth app with D3VONN redirect URLs.

## Files changed
- src/components/agent/tabs/CreateAgentTab.tsx
- docs/integrations/GOOGLE_DRIVE_USER_AUTH.md