### PR TITLE
Fix Hermes VPS healthcheck status check

### DIFF
--- a/deploy/vps/scripts/healthcheck.sh
+++ b/deploy/vps/scripts/healthcheck.sh
@@ -30,7 +30,7 @@ check_service "Nginx" "curl -sf http://localhost/health"
 check_service "Backend API live" "docker exec d3vonn-backend curl -sf http://localhost:8000/health/live"
 check_service "Backend API ready" "docker exec d3vonn-backend curl -sf http://localhost:8000/health/ready"
 check_service "Redis" "docker exec d3vonn-redis redis-cli ping"
-check_service "Hermes" "docker inspect --format='{{.State.Health.Status}}' d3vonn-hermes 2>/dev/null | grep -q healthy"
+check_service "Hermes" "docker inspect --format='{{.State.Running}}' d3vonn-hermes 2>/dev/null | grep -q true"
 
 # Worker services
 check_service "Celery Worker" "docker inspect --format='{{.State.Running}}' d3vonn-celery-worker 2>/dev/null | grep -q true"


### PR DESCRIPTION
## Summary

Updates the VPS healthcheck script so Hermes is checked by container running state instead of Docker health status.

## Why

`deploy/vps/docker-compose.yml` currently disables the Hermes container healthcheck. The previous script used:

```bash
docker inspect --format='{{.State.Health.Status}}' d3vonn-hermes 2>/dev/null | grep -q healthy
```

That can report Hermes as unhealthy even when the container is running correctly, because no Docker health status exists for that service.

## Change

Hermes now follows the same pattern used by Celery and agent containers:

```bash
docker inspect --format='{{.State.Running}}' d3vonn-hermes 2>/dev/null | grep -q true
```

## Testing

Not run locally. This is a one-line shell check alignment with the current Compose configuration.