### PR TITLE
Add VPS HTTPS routing for api.d3vonn.io

### DIFF
--- a/deploy/vps/nginx/conf.d/d3vonn.conf
+++ b/deploy/vps/nginx/conf.d/d3vonn.conf
@@ -1,31 +1,89 @@
 # =============================================================================
-# D3VONN.IO — VPS HTTP Bootstrap Virtual Host Configuration
+# D3VONN.IO — VPS Virtual Host Configuration
 # =============================================================================
-# This bootstrap config intentionally listens on HTTP only. It keeps Nginx
-# startable on a fresh VPS before Let's Encrypt certificates exist. After DNS is
-# pointed at the VPS and certificates are issued, replace this with the HTTPS
-# production configuration.
+# HTTP stays available for ACME challenges and redirects API traffic to HTTPS.
+# HTTPS terminates TLS inside the VPS Nginx container and routes api.d3vonn.io
+# directly to the FastAPI backend container.
+#
+# Expected certificate paths inside the Nginx container:
+#   /etc/nginx/ssl/live/api.d3vonn.io/fullchain.pem
+#   /etc/nginx/ssl/live/api.d3vonn.io/privkey.pem
+# The docker-compose.yml mount maps deploy/vps/ssl/certs to /etc/nginx/ssl.
+# =============================================================================
 
+# HTTP bootstrap + ACME + redirect for API domain.
 server {
     listen 80;
     listen [::]:80;
-    server_name d3vonn.io www.d3vonn.io api.d3vonn.io _;
+    server_name api.d3vonn.io;
 
-    # Health check endpoint for Docker, load balancers, and smoke tests.
+    location /.well-known/acme-challenge/ {
+        root /var/www/certbot;
+    }
+
     location /health {
         access_log off;
         add_header Content-Type text/plain;
         return 200 "OK\n";
     }
 
-    # ACME challenge path for future Let's Encrypt issuance.
-    location /.well-known/acme-challenge/ {
-        root /var/www/certbot;
+    location / {
+        return 301 https://$host$request_uri;
+    }
+}
+
+# HTTPS API virtual host.
+server {
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
+    server_name api.d3vonn.io;
+
+    ssl_certificate /etc/nginx/ssl/live/api.d3vonn.io/fullchain.pem;
+    ssl_certificate_key /etc/nginx/ssl/live/api.d3vonn.io/privkey.pem;
+    ssl_protocols TLSv1.2 TLSv1.3;
+    ssl_prefer_server_ciphers off;
+    ssl_session_timeout 1d;
+    ssl_session_cache shared:SSL:10m;
+    ssl_session_tickets off;
+
+    add_header X-Content-Type-Options nosniff always;
+    add_header X-Frame-Options DENY always;
+    add_header Referrer-Policy no-referrer-when-downgrade always;
+
+    location /health {
+        proxy_pass http://backend_api;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto https;
+        proxy_connect_timeout 30s;
+        proxy_send_timeout 60s;
+        proxy_read_timeout 120s;
     }
 
-    # API subdomain routes straight to FastAPI.
-    if ($host = api.d3vonn.io) {
-        set $is_api_host 1;
+    location /health/live {
+        proxy_pass http://backend_api;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto https;
+        proxy_connect_timeout 30s;
+        proxy_send_timeout 60s;
+        proxy_read_timeout 120s;
+    }
+
+    location /health/ready {
+        proxy_pass http://backend_api;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto https;
+        proxy_connect_timeout 30s;
+        proxy_send_timeout 60s;
+        proxy_read_timeout 120s;
     }
 
     location /api/ {
@@ -34,7 +92,7 @@ server {
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Proto https;
         proxy_set_header Connection "";
         proxy_connect_timeout 30s;
         proxy_send_timeout 60s;
@@ -49,22 +107,42 @@ server {
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto https;
         proxy_read_timeout 3600s;
         proxy_send_timeout 3600s;
     }
 
-    location /grafana/ {
-        return 503 "Grafana is not enabled on this VPS stack.\n";
-    }
-
-    # For requests directly to api.d3vonn.io without /api prefix.
-    location /health/live {
+    location / {
         proxy_pass http://backend_api;
         proxy_http_version 1.1;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Proto https;
+        proxy_connect_timeout 30s;
+        proxy_send_timeout 60s;
+        proxy_read_timeout 120s;
+    }
+}
+
+# HTTP frontend virtual host.
+server {
+    listen 80;
+    listen [::]:80;
+    server_name d3vonn.io www.d3vonn.io _;
+
+    location /health {
+        access_log off;
+        add_header Content-Type text/plain;
+        return 200 "OK\n";
+    }
+
+    location /.well-known/acme-challenge/ {
+        root /var/www/certbot;
+    }
+
+    location /grafana/ {
+        return 503 "Grafana is not enabled on this VPS stack.\n";
     }
 
     location / {


### PR DESCRIPTION
## Summary

Adds a dedicated HTTPS Nginx virtual host for `api.d3vonn.io` on the Hostinger VPS.

## Why

After DNS cutover, public HTTPS requests to `api.d3vonn.io` were still showing Railway headers. Repo inspection showed the VPS Nginx config only had an HTTP bootstrap server block, so HTTPS for the API domain was not explicitly terminated and routed by this Nginx config.

## Changes

- Adds an HTTP `api.d3vonn.io` server block for ACME challenges and redirect to HTTPS.
- Adds a 443 SSL server block for `api.d3vonn.io`.
- Routes these API-domain paths directly to the FastAPI backend upstream:
  - `/health`
  - `/health/live`
  - `/health/ready`
  - `/api/*`
  - `/ws/*`
  - fallback `/`
- Keeps the frontend HTTP virtual host separate for `d3vonn.io` / `www.d3vonn.io`.

## Expected certificate paths

```text
/etc/nginx/ssl/live/api.d3vonn.io/fullchain.pem
/etc/nginx/ssl/live/api.d3vonn.io/privkey.pem
```

These map from the existing Compose mount:

```text
./ssl/certs:/etc/nginx/ssl:ro
```

## VPS rollout

```bash
cd /opt/supreme-ai-deployment-hub
git pull

docker compose --env-file deploy/vps/env/.env.production -f deploy/vps/docker-compose.yml config

docker exec d3vonn-nginx nginx -t

docker compose --env-file deploy/vps/env/.env.production -f deploy/vps/docker-compose.yml up -d --force-recreate nginx

curl -i -H "Host: api.d3vonn.io" http://127.0.0.1/health/ready
curl -i https://api.d3vonn.io/health/ready
```

## Notes

If `nginx -t` fails because the certificate paths do not exist, issue/copy the Let's Encrypt certificate into the mounted `deploy/vps/ssl/certs/live/api.d3vonn.io/` directory before recreating Nginx.