### PR TITLE
feat(home): add public homepage telemetry adapter

### DIFF
--- a/src/lib/homepageTelemetry.ts
+++ b/src/lib/homepageTelemetry.ts
@@ -1,0 +1,58 @@
+export type HomepageTelemetry = {
+  activeAgents: string;
+  workflowsToday: string;
+  knowledgeNodes: string;
+  systemStatus: string;
+  hermesQueue: string;
+};
+
+export const defaultHomepageTelemetry: HomepageTelemetry = {
+  activeAgents: 'Live',
+  workflowsToday: 'Demo',
+  knowledgeNodes: 'Ready',
+  systemStatus: 'Operational',
+  hermesQueue: 'Standby',
+};
+
+type PublicStatsResponse = {
+  active_agents?: number | string;
+  completed_workflows?: number | string;
+  uptime_percent?: number | string;
+  queue_pending?: number | string;
+  total_tasks_processed?: number | string;
+  system_health?: string;
+};
+
+const formatNumber = (value: unknown, fallback: string): string => {
+  if (typeof value === 'number' && Number.isFinite(value)) return value.toLocaleString();
+  if (typeof value === 'string' && value.trim()) return value;
+  return fallback;
+};
+
+export const normalizePublicStats = (stats: PublicStatsResponse | null | undefined): HomepageTelemetry => {
+  if (!stats) return defaultHomepageTelemetry;
+
+  return {
+    activeAgents: formatNumber(stats.active_agents, defaultHomepageTelemetry.activeAgents),
+    workflowsToday: formatNumber(stats.completed_workflows, defaultHomepageTelemetry.workflowsToday),
+    knowledgeNodes: formatNumber(stats.total_tasks_processed, defaultHomepageTelemetry.knowledgeNodes),
+    systemStatus: stats.system_health || defaultHomepageTelemetry.systemStatus,
+    hermesQueue: formatNumber(stats.queue_pending, defaultHomepageTelemetry.hermesQueue),
+  };
+};
+
+export async function fetchHomepageTelemetry(signal?: AbortSignal): Promise<HomepageTelemetry> {
+  try {
+    const response = await fetch('/api/public/stats', {
+      signal,
+      headers: { Accept: 'application/json' },
+    });
+
+    if (!response.ok) return defaultHomepageTelemetry;
+
+    const payload = (await response.json()) as PublicStatsResponse;
+    return normalizePublicStats(payload);
+  } catch {
+    return defaultHomepageTelemetry;
+  }
+}

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -15,7 +15,6 @@ import {
   Network,
   BookOpen,
   Clapperboard,
-  Megaphone,
   ShoppingCart,
   Code2,
   Cloud,
@@ -28,54 +27,22 @@ import {
 } from 'lucide-react';
 import Footer from '@/components/Footer';
 import SmartLaunchLink from '@/components/SmartLaunchLink';
+import {
+  defaultHomepageTelemetry,
+  fetchHomepageTelemetry,
+  type HomepageTelemetry,
+} from '@/lib/homepageTelemetry';
 
 const MASTER_LOGO_SRC = '/d3vonn-logo-live.svg';
 
-type Telemetry = {
-  activeAgents: string;
-  workflowsToday: string;
-  knowledgeNodes: string;
-  systemStatus: string;
-  hermesQueue: string;
-};
-
-const defaultTelemetry: Telemetry = {
-  activeAgents: 'Live',
-  workflowsToday: '41/41',
-  knowledgeNodes: '573+',
-  systemStatus: 'Optimal',
-  hermesQueue: 'Ready',
-};
-
 const useHomepageTelemetry = () => {
-  const [telemetry, setTelemetry] = useState<Telemetry>(defaultTelemetry);
+  const [telemetry, setTelemetry] = useState<HomepageTelemetry>(defaultHomepageTelemetry);
 
   useEffect(() => {
     const controller = new AbortController();
 
-    const load = async () => {
-      try {
-        const [overview, occ] = await Promise.allSettled([
-          fetch('/api/admin/overview', { signal: controller.signal }).then((r) => (r.ok ? r.json() : null)),
-          fetch('/api/occ/stats', { signal: controller.signal }).then((r) => (r.ok ? r.json() : null)),
-        ]);
+    fetchHomepageTelemetry(controller.signal).then(setTelemetry);
 
-        const overviewValue = overview.status === 'fulfilled' ? overview.value : null;
-        const occValue = occ.status === 'fulfilled' ? occ.value : null;
-
-        setTelemetry({
-          activeAgents: String(overviewValue?.active_agents ?? overviewValue?.agents_active ?? defaultTelemetry.activeAgents),
-          workflowsToday: String(occValue?.workflows_today ?? occValue?.tasks_completed ?? defaultTelemetry.workflowsToday),
-          knowledgeNodes: String(overviewValue?.knowledge_nodes ?? occValue?.rag_documents ?? defaultTelemetry.knowledgeNodes),
-          systemStatus: String(overviewValue?.status ?? occValue?.status ?? defaultTelemetry.systemStatus),
-          hermesQueue: String(occValue?.hermes_queue ?? overviewValue?.queue_status ?? defaultTelemetry.hermesQueue),
-        });
-      } catch {
-        setTelemetry(defaultTelemetry);
-      }
-    };
-
-    load();
     return () => controller.abort();
   }, []);
 


### PR DESCRIPTION
## Summary
- Adds a public-safe homepage telemetry adapter for `/api/public/stats`.
- Normalizes public stats into the existing homepage metric shape.
- Keeps safe demo fallback values when the public endpoint is unavailable.
- Wires `src/pages/Index.tsx` to use the adapter instead of direct `/api/admin/*` or `/api/occ/*` calls.

## Linked issue
- Advances #297

## Notes
No secrets, environment files, or backend behavior changed. This keeps the public homepage on the existing public stats contract.