### PR TITLE
Hardening: production phase 1 headers, env template, and audit plan

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,73 +1,85 @@
-# .env.example — Copy to .env and fill in your values before running locally
-# Never commit a .env file with real values. This file is safe to commit.
+# .env.example — safe template only
+# Copy to .env for local development or deploy/vps/env/.env.production for VPS production.
+# Never commit real secrets, access tokens, private keys, service role keys, or production credentials.
 
-# ─── Required ─────────────────────────────────────────────────────────────────
-GITHUB_TOKEN=ghp_your_token_here
-OPENAI_API_KEY=sk-your_openai_key_here
+# ─── Runtime ──────────────────────────────────────────────────────────────────
+APP_ENV=production
+ENVIRONMENT=production
+LOG_LEVEL=info
+DOMAIN=d3vonn.io
+API_DOMAIN=api.d3vonn.io
 
-# ─── D3VONN.IO Public Frontend Takeover ───────────────────────────────────────
-# d3vonn.io inherits the working Devonn backend until AWS runtime is activated.
-VITE_D3VONN_API_URL=https://devonn-ai-api.up.railway.app
-VITE_DEVONN_API_URL=https://devonn-ai-api.up.railway.app
-VITE_API_URL=https://devonn-ai-api.up.railway.app
-VITE_DKOS_INGESTION_API_URL=
-VITE_SUPABASE_URL=https://tjygexesognbkwualywq.supabase.co
-VITE_HERMES_HEALTH_URL=https://devonn-ai-api.up.railway.app/health
+# ─── Public Frontend URLs ─────────────────────────────────────────────────────
+# Public VITE_* values are visible in browser builds. Never place service-role keys here.
+VITE_API_URL=https://api.d3vonn.io
+VITE_D3VONN_API_URL=https://api.d3vonn.io
+VITE_DEVONN_API_URL=https://api.d3vonn.io
+VITE_DKOS_INGESTION_API_URL=https://api.d3vonn.io
+VITE_HERMES_HEALTH_URL=https://api.d3vonn.io/health/live
 VITE_AWS_HEALTH_URL=
+VITE_SUPABASE_URL=https://your-project.supabase.co
+VITE_SUPABASE_ANON_KEY=replace-with-supabase-anon-key
+VITE_SUPABASE_PUBLISHABLE_KEY=replace-with-supabase-anon-key
+VITE_ENVIRONMENT=production
 
-# ─── Devonn Ecosystem ─────────────────────────────────────────────────────────
-ORGANIZATION=wesship
-WORKSPACE_DIR=~/DevonnAI_AutoHealer
-CLONE_PROTOCOL=https                  # https or ssh
-
-# ─── DevonnBench ──────────────────────────────────────────────────────────────
-DEVONN_BASE_URL=                       # e.g. https://api.d3vonn.io
-DEVONN_API_TOKEN=                      # Devonn API token; never commit a real token
-DEVONN_ENV=local                       # local | ci | staging | production
-
-# ─── Service URLs ─────────────────────────────────────────────────────────────
-ORCHESTRATOR_URL=https://central-orchestrator.onrender.com
-GATEWAY_URL=https://openclaw-gateway-2t9e.onrender.com
-
-# ─── Hermes Orchestrator ──────────────────────────────────────────────────────
-POLL_INTERVAL=30                      # seconds between queue polls
-HERMES_WEBHOOK_SECRET=                # openssl rand -hex 32
-HERMES_INTERNAL_API_KEY=              # openssl rand -hex 32  (Railway ↔ Supabase)
-HERMES_BYPASS=false                   # CI-only emergency bypass — never true in production
-
-# ─── Voice Layer (VAPI) ───────────────────────────────────────────────────────
-VAPI_PUBLIC_KEY=                      # from app.vapi.ai → Account → API Keys
-VAPI_PRIVATE_KEY=                     # from app.vapi.ai → Account → API Keys
-VAPI_WEBHOOK_SECRET=                  # openssl rand -hex 32
+# ─── Backend / API ────────────────────────────────────────────────────────────
+BACKEND_PORT=8000
+ALLOWED_ORIGINS=https://d3vonn.io,https://www.d3vonn.io,https://app.d3vonn.io
+CORS_ORIGINS=https://d3vonn.io,https://www.d3vonn.io,https://app.d3vonn.io
+JWT_SECRET=replace-with-strong-random-secret
+DEVONN_BASE_URL=https://api.d3vonn.io
+DEVONN_API_TOKEN=replace-with-devonn-api-token
+DEVONN_ENV=production
 
 # ─── Supabase ─────────────────────────────────────────────────────────────────
-SUPABASE_URL=                         # https://xxxx.supabase.co
-SUPABASE_ANON_KEY=                    # from Supabase → Settings → API → anon/public
-SUPABASE_SERVICE_ROLE_KEY=            # from Supabase → Settings → API → service_role
+SUPABASE_URL=https://your-project.supabase.co
+SUPABASE_ANON_KEY=replace-with-supabase-anon-key
+SUPABASE_SERVICE_ROLE_KEY=replace-with-supabase-service-role-key
 
-# ─── AI / LLM ─────────────────────────────────────────────────────────────────
+# ─── Redis / Queue ────────────────────────────────────────────────────────────
+REDIS_URL=redis://redis:6379/0
+CELERY_BROKER_URL=redis://redis:6379/1
+CELERY_RESULT_BACKEND=redis://redis:6379/2
+
+# ─── AI / LLM Providers ───────────────────────────────────────────────────────
+OPENAI_API_KEY=replace-with-openai-api-key
+ANTHROPIC_API_KEY=replace-with-anthropic-api-key
+GOOGLE_AI_API_KEY=replace-with-google-ai-api-key
 OPENAI_EMBEDDING_MODEL=text-embedding-3-small
-LOVABLE_API_KEY=                      # from lovable.dev → Settings → API
+EMBEDDING_MODEL=text-embedding-3-small
 
-# ─── RAG Tuning (optional) ────────────────────────────────────────────────────
+# ─── Pinecone / RAG ───────────────────────────────────────────────────────────
+PINECONE_API_KEY=replace-with-pinecone-api-key
+PINECONE_HOST=replace-with-pinecone-host
+PINECONE_INDEX=devonn-rag
 RAG_MAX_FILE_SIZE_BYTES=10485760
 RAG_CHUNK_SIZE_CHARS=1400
 RAG_CHUNK_OVERLAP_CHARS=180
 
-# ─── Pinecone ─────────────────────────────────────────────────────────────────
-PINECONE_API_KEY=                     # from app.pinecone.io → API Keys
-PINECONE_INDEX=devonn-rag             # name of your Pinecone index
+# ─── Hermes Orchestrator ──────────────────────────────────────────────────────
+HERMES_MODE=orchestrator
+HERMES_DEFAULT_AGENT=TARS
+HERMES_MAX_CONCURRENT_TASKS=10
+HERMES_POLL_INTERVAL_SECONDS=10
+HERMES_MAX_TASKS_PER_TICK=5
+HERMES_WEBHOOK_SECRET=replace-with-random-webhook-secret
+HERMES_INTERNAL_API_KEY=replace-with-random-internal-api-key
+HERMES_BYPASS=false
 
-# ─── MCP API (supreme-ai-deployment-hub) ──────────────────────────────────────
-JWT_SECRET=your_jwt_secret_here       # from Supabase → Settings → API → JWT Secret
-DB_USERNAME=your_db_user
-DB_PASSWORD=your_db_password
-DB_NAME=devonn
+# ─── Voice / Telephony ────────────────────────────────────────────────────────
+TWILIO_ACCOUNT_SID=replace-with-twilio-account-sid
+TWILIO_AUTH_TOKEN=replace-with-twilio-auth-token
+TWILIO_FROM_NUMBER=+10000000000
+VAPI_PUBLIC_KEY=replace-with-vapi-public-key
+VAPI_PRIVATE_KEY=replace-with-vapi-private-key
+VAPI_WEBHOOK_SECRET=replace-with-random-vapi-webhook-secret
 
-# ─── Runtime ──────────────────────────────────────────────────────────────────
-ENVIRONMENT=production                # production | staging | development
+# ─── Observability ────────────────────────────────────────────────────────────
+SENTRY_DSN=
+SLACK_WEBHOOK_URL=
+NOTIFICATION_EMAIL=
 
-# ─── Cloud Providers (optional) ───────────────────────────────────────────────
+# ─── Optional Cloud Providers ─────────────────────────────────────────────────
 AWS_ACCESS_KEY_ID=
 AWS_SECRET_ACCESS_KEY=
 AWS_ROLE_ARN=
@@ -77,6 +89,9 @@ AZURE_TENANT_ID=
 AZURE_SUBSCRIPTION_ID=
 GCP_CREDENTIALS_JSON=
 
-# ─── Notifications (optional) ─────────────────────────────────────────────────
-SLACK_WEBHOOK_URL=
-NOTIFICATION_EMAIL=
+# ─── Local Automation / GitHub ────────────────────────────────────────────────
+# Prefer GitHub Actions secrets or SSH deploy keys. Do not commit real tokens.
+GITHUB_TOKEN=replace-with-github-token-if-needed
+ORGANIZATION=wesship
+WORKSPACE_DIR=~/DevonnAI_AutoHealer
+CLONE_PROTOCOL=ssh

--- a/deploy/vps/nginx/conf.d/d3vonn.conf
+++ b/deploy/vps/nginx/conf.d/d3vonn.conf
@@ -47,11 +47,15 @@ server {
     ssl_session_cache shared:SSL:10m;
     ssl_session_tickets off;
 
-    add_header X-Content-Type-Options nosniff always;
-    add_header X-Frame-Options DENY always;
-    add_header Referrer-Policy no-referrer-when-downgrade always;
+    add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header X-Frame-Options "DENY" always;
+    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+    add_header Permissions-Policy "camera=(), microphone=(), geolocation=()" always;
+    add_header Content-Security-Policy "default-src 'none'; frame-ancestors 'none'; base-uri 'none'; form-action 'none'" always;
 
     location /health {
+        limit_req zone=general burst=20 nodelay;
         proxy_pass http://backend_api;
         proxy_http_version 1.1;
         proxy_set_header Host $host;
@@ -64,6 +68,7 @@ server {
     }
 
     location /health/live {
+        limit_req zone=general burst=20 nodelay;
         proxy_pass http://backend_api;
         proxy_http_version 1.1;
         proxy_set_header Host $host;
@@ -76,6 +81,7 @@ server {
     }
 
     location /health/ready {
+        limit_req zone=general burst=20 nodelay;
         proxy_pass http://backend_api;
         proxy_http_version 1.1;
         proxy_set_header Host $host;
@@ -87,7 +93,22 @@ server {
         proxy_read_timeout 120s;
     }
 
+    location /api/auth/ {
+        limit_req zone=login burst=5 nodelay;
+        proxy_pass http://backend_api/;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto https;
+        proxy_set_header Connection "";
+        proxy_connect_timeout 30s;
+        proxy_send_timeout 60s;
+        proxy_read_timeout 120s;
+    }
+
     location /api/ {
+        limit_req zone=api burst=20 nodelay;
         proxy_pass http://backend_api/;
         proxy_http_version 1.1;
         proxy_set_header Host $host;
@@ -101,6 +122,7 @@ server {
     }
 
     location /ws/ {
+        limit_req zone=api burst=20 nodelay;
         proxy_pass http://backend_api;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
@@ -114,6 +136,7 @@ server {
     }
 
     location / {
+        limit_req zone=general burst=30 nodelay;
         proxy_pass http://backend_api;
         proxy_http_version 1.1;
         proxy_set_header Host $host;
@@ -132,6 +155,12 @@ server {
     listen [::]:80;
     server_name d3vonn.io www.d3vonn.io _;
 
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header X-Frame-Options "DENY" always;
+    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+    add_header Permissions-Policy "camera=(), microphone=(), geolocation=()" always;
+    add_header Content-Security-Policy "default-src 'self'; img-src 'self' data: https:; script-src 'self'; style-src 'self' 'unsafe-inline'; connect-src 'self' https://api.d3vonn.io https://*.supabase.co wss://*.supabase.co; font-src 'self' data:; frame-ancestors 'none'; base-uri 'self'; form-action 'self'" always;
+
     location /health {
         access_log off;
         add_header Content-Type text/plain;
@@ -147,6 +176,7 @@ server {
     }
 
     location / {
+        limit_req zone=general burst=50 nodelay;
         root /usr/share/nginx/html;
         index index.html;
         try_files $uri $uri/ /index.html;

--- a/docs/production/production-hardening-phase-1.md
+++ b/docs/production/production-hardening-phase-1.md
@@ -1,0 +1,103 @@
+# D3VONN.IO Production Hardening Phase 1
+
+## Objective
+
+Make the VPS deployment secure, observable, recoverable, and production-safe before adding more features, agents, dashboards, or integrations.
+
+## Current evidence from repository inspection
+
+### Already in place
+
+- VPS Docker Compose exists at `deploy/vps/docker-compose.yml`.
+- VPS Nginx main config exists at `deploy/vps/nginx/nginx.conf`.
+- API virtual host exists at `deploy/vps/nginx/conf.d/d3vonn.conf`.
+- Redis is internal-only through `expose: 6379` and no public host port binding.
+- Backend is bound to localhost only with `127.0.0.1:${BACKEND_PORT:-8000}:8000` and is also exposed internally to Nginx.
+- Backend health check targets `/health/live`.
+- Nginx main config already defines gzip compression, JSON access logs, and rate-limit zones.
+
+### Phase 1 changes applied on this branch
+
+- Refreshed `.env.example` into a safe production template using placeholders only.
+- Removed stale Railway defaults from the production-facing environment template.
+- Clarified that `VITE_*` values are public and must not contain service-role secrets.
+- Tightened API security headers.
+- Added API HSTS for `api.d3vonn.io`.
+- Added a strict API CSP.
+- Added frontend security headers.
+- Added frontend CSP tuned for D3VONN.IO, Supabase, and the API domain.
+- Added Nginx `limit_req` usage to health, auth, API, websocket, and frontend routes.
+
+## Critical validation before merge
+
+Run from `deploy/vps` on the VPS:
+
+```bash
+docker compose --env-file env/.env.production -f docker-compose.yml config
+docker compose --env-file env/.env.production -f docker-compose.yml exec nginx nginx -t
+```
+
+Then test the live endpoints:
+
+```bash
+curl -I https://api.d3vonn.io/health/live
+curl -I https://api.d3vonn.io/health/ready
+curl -I http://d3vonn.io
+```
+
+Confirm the expected headers are present:
+
+- `X-Content-Type-Options`
+- `X-Frame-Options`
+- `Referrer-Policy`
+- `Permissions-Policy`
+- `Content-Security-Policy`
+- `Strict-Transport-Security` on the API domain only
+
+## Known caution
+
+The frontend virtual host currently serves `d3vonn.io` and `www.d3vonn.io` on port 80. Do not add global HSTS for the frontend until HTTPS termination for the frontend domain is confirmed.
+
+## Next PR sequence
+
+1. Validate and merge Nginx/env hardening.
+2. Add or strengthen CI validation for VPS Compose and Nginx config.
+3. Audit workflows and retire stale duplicate deploy paths.
+4. Add observability checks for `/health/live`, `/health/ready`, logs, disk, SSL expiry, and queue depth.
+5. Add Hermes/RAG/memory production audit tests.
+
+## Production readiness checklist
+
+### Security
+
+- [ ] Secrets rotated if any were pasted into chat, screenshots, terminal logs, or previous commits.
+- [ ] `.env.production` exists only on the VPS and is not tracked.
+- [ ] Redis has no public port binding.
+- [ ] Backend is not publicly exposed beyond Nginx/API routing.
+- [ ] API security headers verified with `curl -I`.
+- [ ] Frontend CSP tested against browser console errors.
+- [ ] Rate limits tested for auth and API routes.
+
+### Reliability
+
+- [ ] Compose config validates.
+- [ ] Nginx config validates.
+- [ ] Health checks pass.
+- [ ] Restart policies are present.
+- [ ] SSL renewal path tested.
+
+### Observability
+
+- [ ] JSON Nginx logs available.
+- [ ] API health endpoints available.
+- [ ] Backend application logs structured.
+- [ ] Queue depth monitoring defined.
+- [ ] Disk usage monitoring defined.
+
+### Agent/RAG/Hermes
+
+- [ ] Hermes ownership documented.
+- [ ] Agent task state transitions tested.
+- [ ] Failed/retried/cancelled tasks visible.
+- [ ] Memory scoped by user/project/session.
+- [ ] RAG citations and source permissions verified.


### PR DESCRIPTION
## Summary

This PR starts **D3VONN.IO Production Hardening Phase 1**.

It focuses on safe production hardening rather than feature expansion:

- Refreshes `.env.example` into a safer production template with placeholders only.
- Removes stale Railway-facing defaults from the production-facing template.
- Clarifies that `VITE_*` values are public browser-build values and must not contain service-role secrets.
- Tightens VPS Nginx headers for the API virtual host.
- Adds HSTS for `api.d3vonn.io` only.
- Adds a strict API CSP.
- Adds frontend CSP/security headers for the HTTP frontend virtual host.
- Applies existing Nginx rate-limit zones to health, auth, API, websocket, and frontend routes.
- Adds a production hardening audit document with validation commands and readiness checklist.

## Validation required before merge

Run on the VPS from `deploy/vps`:

```bash
docker compose --env-file env/.env.production -f docker-compose.yml config
docker compose --env-file env/.env.production -f docker-compose.yml exec nginx nginx -t
```

Then verify headers:

```bash
curl -I https://api.d3vonn.io/health/live
curl -I https://api.d3vonn.io/health/ready
curl -I http://d3vonn.io
```

## Caution

The frontend virtual host currently serves `d3vonn.io` / `www.d3vonn.io` on port 80. This PR does **not** add frontend HSTS because HTTPS termination for the frontend domain must be confirmed first.

## Production safety

This PR does not intentionally trigger a production deployment. It should be validated through Compose/Nginx checks before merge and rollout.