### PR TITLE
CI: stabilize E2E dependency install

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -33,6 +33,9 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda
+        with:
+          version: 9.15.9
+          run_install: false
 
       - name: Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
@@ -41,7 +44,10 @@ jobs:
           cache: pnpm
 
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        env:
+          PUPPETEER_SKIP_DOWNLOAD: "true"
+          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: "1"
+        run: pnpm install --frozen-lockfile --reporter=append-only
 
       - name: Install Playwright browser (${{ matrix.browser }})
         run: pnpm exec playwright install --with-deps ${{ matrix.browser }}

--- a/package.json
+++ b/package.json
@@ -118,9 +118,9 @@
     "sonner": "^1.5.0",
     "tailwind-merge": "^2.5.2",
     "tailwindcss-animate": "^1.0.7",
-    "uuid": "^11.1.0",
+    "uuid": "^11.1.1",
     "vaul": "^0.9.3",
-    "vitest": "^4.1.8",
+    "vitest": "^4.1.2",
     "zod": "^4.3.6"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

Stabilizes the Playwright E2E workflow dependency install path.

## Changes

- Pins pnpm to `9.15.9`.
- Uses explicit pnpm setup with `run_install: false`.
- Skips browser downloads during the general dependency install.
- Keeps the explicit per-browser Playwright install step.
- Aligns `package.json` specifiers with the existing lockfile:
  - `uuid`: `^11.1.1`
  - `vitest`: `^4.1.2`

## Validation

Latest E2E matrix is green:

- Chromium: success
- Firefox: success
- WebKit: success

## Production safety

No application runtime code or deployment config changed.