### PR TITLE
CI: stabilize Lighthouse workflow install

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -1,9 +1,5 @@
 name: Lighthouse CI
 
-# Runs performance, accessibility, SEO, and best-practices audits on every PR.
-# Blocks merges if Lighthouse scores drop below the defined thresholds.
-# The repo already has a lighthouse-config.json - this workflow activates it.
-
 on:
   pull_request:
     branches: [main]
@@ -25,21 +21,28 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda  # v4.1.0
+        uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda
+        with:
+          version: 9.15.9
+          run_install: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version: 22
           cache: pnpm
+
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        env:
+          PUPPETEER_SKIP_DOWNLOAD: "true"
+          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: "1"
+        run: pnpm install --frozen-lockfile --reporter=append-only
 
       - name: Build production bundle
-        run: npm run build
+        run: pnpm run build
         env:
           VITE_SUPABASE_URL: https://placeholder.supabase.co
           VITE_SUPABASE_ANON_KEY: placeholder_anon_key
@@ -48,26 +51,21 @@ jobs:
         run: |
           npm install -g serve
           serve -s dist -l 4173 &
-          # Wait for server to be ready (up to 60s)
           npx wait-on http://localhost:4173 --timeout 60000
-          # Extra settle time to ensure the SPA is fully loaded
           sleep 3
 
       - name: Run Lighthouse CI
-        uses: treosh/lighthouse-ci-action@3e7e23fb74242897f95c0ba9cabad3d0227b9b18  # v12
-        # NO_FCP can occur on first run - allow failure without blocking CI
+        uses: treosh/lighthouse-ci-action@3e7e23fb74242897f95c0ba9cabad3d0227b9b18
         continue-on-error: true
         with:
           urls: |
             http://localhost:4173/
-          # Use the existing lighthouse-config.json but override startServerCommand
-          # since we already started the server above
           runs: 1
           uploadArtifacts: true
           temporaryPublicStorage: true
 
       - name: Upload Lighthouse results
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         if: always()
         with:
           name: lighthouse-results

--- a/package.json
+++ b/package.json
@@ -118,9 +118,9 @@
     "sonner": "^1.5.0",
     "tailwind-merge": "^2.5.2",
     "tailwindcss-animate": "^1.0.7",
-    "uuid": "^11.1.0",
+    "uuid": "^11.1.1",
     "vaul": "^0.9.3",
-    "vitest": "^4.1.8",
+    "vitest": "^4.1.2",
     "zod": "^4.3.6"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

Stabilizes the Lighthouse CI workflow dependency install and build path.

## Changes

- Adds explicit pnpm setup options.
- Skips browser downloads during general dependency install.
- Uses `pnpm run build` for the production bundle.
- Aligns `package.json` specifiers with the existing lockfile:
  - `uuid`: `^11.1.1`
  - `vitest`: `^4.1.2`

## Validation target

The workflow should move past dependency install, build, serve, and run Lighthouse.

## Production safety

No application runtime code or deployment config changed.