### PR TITLE
CI: stabilize Accessibility workflow install

### DIFF
--- a/.github/workflows/accessibility.yml
+++ b/.github/workflows/accessibility.yml
@@ -1,11 +1,5 @@
 name: Accessibility CI
 
-# Runs automated accessibility audits on every PR using axe-core and pa11y.
-# Fails the PR if any WCAG 2.1 AA violations are detected.
-#
-# Required secrets:
-#   None - runs against the built preview
-
 on:
   pull_request:
   push:
@@ -25,20 +19,27 @@ jobs:
     timeout-minutes: 15
 
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda  # v4.1.0
+        uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda
+        with:
+          version: 9.15.9
+          run_install: false
 
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version: 22
           cache: pnpm
+
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        env:
+          PUPPETEER_SKIP_DOWNLOAD: "true"
+          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: "1"
+        run: pnpm install --frozen-lockfile --reporter=append-only
 
       - name: Build application
-        run: npm run build
+        run: pnpm run build
         env:
           VITE_API_URL: https://api.d3vonn.io
           VITE_SUPABASE_URL: https://placeholder.supabase.co
@@ -56,7 +57,6 @@ jobs:
 
       - name: Run axe accessibility audit
         run: |
-          # axe-core CLI uses --save for JSON output (--output-file not supported)
           axe http://localhost:4173 \
             --tags wcag2a,wcag2aa,wcag21aa \
             --save axe-results.json || true
@@ -86,7 +86,7 @@ jobs:
 
       - name: Upload axe results
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: axe-accessibility-results
           path: axe-results.json
@@ -99,20 +99,27 @@ jobs:
     needs: axe-audit
 
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda  # v4.1.0
+        uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda
+        with:
+          version: 9.15.9
+          run_install: false
 
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version: 22
           cache: pnpm
+
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile && npm install -g pa11y-ci
+        env:
+          PUPPETEER_SKIP_DOWNLOAD: "true"
+          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: "1"
+        run: pnpm install --frozen-lockfile --reporter=append-only && npm install -g pa11y-ci
 
       - name: Build application
-        run: npm run build
+        run: pnpm run build
         env:
           VITE_API_URL: https://api.d3vonn.io
           VITE_SUPABASE_URL: https://placeholder.supabase.co
@@ -125,7 +132,5 @@ jobs:
         run: npx wait-on http://localhost:4173 --timeout 30000
 
       - name: Run pa11y-ci
-        # pa11y-ci reads standard/reporter/urls from .pa11yci config file
-        # --standard and --reporter are NOT valid CLI flags for pa11y-ci (they are pa11y flags)
         run: pa11y-ci --config .pa11yci
         continue-on-error: true

--- a/package.json
+++ b/package.json
@@ -118,9 +118,9 @@
     "sonner": "^1.5.0",
     "tailwind-merge": "^2.5.2",
     "tailwindcss-animate": "^1.0.7",
-    "uuid": "^11.1.0",
+    "uuid": "^11.1.1",
     "vaul": "^0.9.3",
-    "vitest": "^4.1.8",
+    "vitest": "^4.1.2",
     "zod": "^4.3.6"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

Stabilizes Accessibility CI install and build paths.

## Changes

- Adds explicit pnpm setup options to axe and pa11y jobs.
- Skips browser downloads during dependency install.
- Uses `pnpm run build` for both accessibility audit jobs.
- Aligns `package.json` specifiers with the existing lockfile:
  - `uuid`: `^11.1.1`
  - `vitest`: `^4.1.2`

## Validation target

The workflow should move past dependency install, build, server startup, axe, and pa11y.

## Production safety

No application runtime code or deployment config changed.