### PR TITLE
feat home wire sections

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -26,7 +26,10 @@ import {
   Bot,
 } from 'lucide-react';
 import Footer from '@/components/Footer';
+import HermesOrchestrationDemo from '@/components/home/HermesOrchestrationDemo';
 import KnowledgeGraphPreview from '@/components/home/KnowledgeGraphPreview';
+import MarketplacePreview from '@/components/home/MarketplacePreview';
+import TrustCenterPreview from '@/components/home/TrustCenterPreview';
 import SmartLaunchLink from '@/components/SmartLaunchLink';
 import {
   defaultHomepageTelemetry,
@@ -448,11 +451,14 @@ const Index: React.FC = () => {
         <Hero />
         <TrustStrip />
         <HowItWorks />
+        <HermesOrchestrationDemo />
         <CapabilitiesStrip />
         <WorkforceSection />
         <ArchitectureSection />
         <KnowledgeGraphPreview />
+        <MarketplacePreview />
         <TrustControlsSection />
+        <TrustCenterPreview />
 
         <Suspense fallback={<div className="bg-[#031f4f] py-24 text-center text-sm text-blue-100/45">Loading...</div>}>
           <BelowFoldSections />


### PR DESCRIPTION
Wires the merged homepage sections into src/pages/Index.tsx. Adds Hermes demo, marketplace preview, and trust center preview to the homepage layout. No secrets or config changed.