### PR TITLE
CI: stabilize Coverage Enforcement

### DIFF
--- a/.github/workflows/coverage-enforcement.yml
+++ b/.github/workflows/coverage-enforcement.yml
@@ -18,22 +18,25 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda  # v4.1.0
+        uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda
         with:
           version: 9.15.9
           run_install: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version: 22
           cache: pnpm
 
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        env:
+          PUPPETEER_SKIP_DOWNLOAD: "true"
+          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: "1"
+        run: pnpm install --frozen-lockfile --ignore-scripts --reporter=append-only
 
       - name: Run coverage when script exists
         run: |

--- a/package.json
+++ b/package.json
@@ -118,9 +118,9 @@
     "sonner": "^1.5.0",
     "tailwind-merge": "^2.5.2",
     "tailwindcss-animate": "^1.0.7",
-    "uuid": "^11.1.0",
+    "uuid": "^11.1.1",
     "vaul": "^0.9.3",
-    "vitest": "^4.1.8",
+    "vitest": "^4.1.2",
     "zod": "^4.3.6"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

Stabilizes Coverage Enforcement CI.

## Changes

- Pins checkout and setup-node by SHA.
- Keeps pnpm at `9.15.9` with `run_install: false`.
- Skips browser downloads during install.
- Uses frozen install with ignore-scripts.
- Aligns `uuid` and `vitest` with the lockfile.

## Safety

No runtime or deployment config changed.