### PR TITLE
CI: stabilize Lockfile Integrity

### DIFF
--- a/.github/workflows/lockfile-integrity.yml
+++ b/.github/workflows/lockfile-integrity.yml
@@ -28,6 +28,9 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda
+        with:
+          version: 9.15.9
+          run_install: false
 
       - name: Set up Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
@@ -35,11 +38,11 @@ jobs:
           node-version: 22
           cache: pnpm
 
-      - name: Enable Corepack
-        run: corepack enable
-
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        env:
+          PUPPETEER_SKIP_DOWNLOAD: "true"
+          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: "1"
+        run: pnpm install --frozen-lockfile --reporter=append-only
 
       - name: Verify lockfile integrity
         run: |

--- a/package.json
+++ b/package.json
@@ -118,9 +118,9 @@
     "sonner": "^1.5.0",
     "tailwind-merge": "^2.5.2",
     "tailwindcss-animate": "^1.0.7",
-    "uuid": "^11.1.0",
+    "uuid": "^11.1.1",
     "vaul": "^0.9.3",
-    "vitest": "^4.1.8",
+    "vitest": "^4.1.2",
     "zod": "^4.3.6"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

Stabilizes Lockfile Integrity CI.

## Changes

- Adds explicit pnpm `9.15.9` setup with `run_install: false`.
- Skips browser downloads during dependency install.
- Uses frozen install with append-only reporting.
- Aligns `uuid` and `vitest` with the lockfile.

## Safety

No runtime or deployment config changed.