### PR TITLE
CI: stabilize Dependency Review trigger

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -8,6 +8,7 @@ on:
       - 'requirements.txt'
       - 'requirements-devonn.txt'
       - 'backend/requirements.txt'
+      - '.github/workflows/dependency-review.yml'
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

Stabilizes Dependency Review CI validation for workflow-only updates.

## Changes

- Keeps the existing pinned dependency-review action.
- Keeps high-severity and GPL/AGPL deny rules unchanged.
- Adds the Dependency Review workflow file to its own PR path filter so this workflow can self-validate when changed.

## Safety

No runtime or deployment config changed.