### PR TITLE
fix: harden Nginx headers and rate limits

### DIFF
--- a/deploy/vps/nginx/conf.d/d3vonn.conf
+++ b/deploy/vps/nginx/conf.d/d3vonn.conf
@@ -47,11 +47,15 @@ server {
     ssl_session_cache shared:SSL:10m;
     ssl_session_tickets off;
 
-    add_header X-Content-Type-Options nosniff always;
-    add_header X-Frame-Options DENY always;
-    add_header Referrer-Policy no-referrer-when-downgrade always;
+    add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header X-Frame-Options "DENY" always;
+    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+    add_header Permissions-Policy "camera=(), microphone=(), geolocation=()" always;
+    add_header Content-Security-Policy "default-src 'none'; frame-ancestors 'none'; base-uri 'none'; form-action 'none'" always;
 
     location /health {
+        limit_req zone=general burst=20 nodelay;
         proxy_pass http://backend_api;
         proxy_http_version 1.1;
         proxy_set_header Host $host;
@@ -64,6 +68,7 @@ server {
     }
 
     location /health/live {
+        limit_req zone=general burst=20 nodelay;
         proxy_pass http://backend_api;
         proxy_http_version 1.1;
         proxy_set_header Host $host;
@@ -76,6 +81,7 @@ server {
     }
 
     location /health/ready {
+        limit_req zone=general burst=20 nodelay;
         proxy_pass http://backend_api;
         proxy_http_version 1.1;
         proxy_set_header Host $host;
@@ -87,7 +93,22 @@ server {
         proxy_read_timeout 120s;
     }
 
+    location /api/auth/ {
+        limit_req zone=login burst=5 nodelay;
+        proxy_pass http://backend_api/;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto https;
+        proxy_set_header Connection "";
+        proxy_connect_timeout 30s;
+        proxy_send_timeout 60s;
+        proxy_read_timeout 120s;
+    }
+
     location /api/ {
+        limit_req zone=api burst=20 nodelay;
         proxy_pass http://backend_api/;
         proxy_http_version 1.1;
         proxy_set_header Host $host;
@@ -101,6 +122,7 @@ server {
     }
 
     location /ws/ {
+        limit_req zone=api burst=20 nodelay;
         proxy_pass http://backend_api;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
@@ -114,6 +136,7 @@ server {
     }
 
     location / {
+        limit_req zone=general burst=30 nodelay;
         proxy_pass http://backend_api;
         proxy_http_version 1.1;
         proxy_set_header Host $host;
@@ -132,6 +155,12 @@ server {
     listen [::]:80;
     server_name d3vonn.io www.d3vonn.io _;
 
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header X-Frame-Options "DENY" always;
+    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+    add_header Permissions-Policy "camera=(), microphone=(), geolocation=()" always;
+    add_header Content-Security-Policy "default-src 'self'; img-src 'self' data: https:; script-src 'self'; style-src 'self' 'unsafe-inline'; connect-src 'self' https://api.d3vonn.io https://*.supabase.co wss://*.supabase.co; font-src 'self' data:; frame-ancestors 'none'; base-uri 'self'; form-action 'self'" always;
+
     location /health {
         access_log off;
         add_header Content-Type text/plain;
@@ -147,6 +176,7 @@ server {
     }
 
     location / {
+        limit_req zone=general burst=50 nodelay;
         root /usr/share/nginx/html;
         index index.html;
         try_files $uri $uri/ /index.html;


### PR DESCRIPTION
## Summary

Carries forward the still-valid parts of the stale production-hardening PR onto current `main`.

## Changes

- Adds API HSTS.
- Tightens `X-Content-Type-Options`, `X-Frame-Options`, and `Referrer-Policy`.
- Adds `Permissions-Policy`.
- Adds a strict CSP for the API virtual host.
- Adds frontend security headers without enabling frontend HSTS.
- Applies existing Nginx rate-limit zones to health, auth, API, websocket handshake, frontend, and fallback routes.
- Adds a dedicated stricter `/api/auth/` rate limit.

## Safety

- Built from current `main` after PRs #327 and #328.
- Does not change Docker services, secrets, environment templates, TLS certificate paths, or backend routing targets.
- Does not add frontend HSTS because frontend HTTPS termination remains separate from this VPS HTTP virtual host.

## VPS validation before rollout

```bash
cd /opt/supreme-ai-deployment-hub
git pull --ff-only

docker compose \
  --env-file deploy/vps/env/.env.production \
  -f deploy/vps/docker-compose.yml \
  config

docker compose \
  --env-file deploy/vps/env/.env.production \
  -f deploy/vps/docker-compose.yml \
  exec nginx nginx -t
```

After deployment:

```bash
curl -I https://api.d3vonn.io/health/live
curl -I https://api.d3vonn.io/health/ready
curl -I https://api.d3vonn.io/api/docs
```

Confirm security headers are present and normal health/API requests are not rate-limited.